### PR TITLE
Let started articles use remaining budget

### DIFF
--- a/js/blog-ai-worker.js
+++ b/js/blog-ai-worker.js
@@ -16537,8 +16537,11 @@ function createArticleGenerationCheckpointer(
       // analysis + continuity repair, ~8-11 calls for the Treaty of Breda
       // attempt), so anything less remaining isn't worth starting.
       const remainingDailyBudget = dailyLimit - budget.dailyUsed;
-      const replacementAlreadyUsed =
+      const openingAnotherRotation =
         budget.rotations >= 2 &&
+        budget.sourceUsed === 0;
+      const replacementAlreadyUsed =
+        openingAnotherRotation &&
         remainingDailyBudget < MIN_VIABLE_ROTATION_BUDGET;
       const sourceLimit = budget.rotations >= 1
         ? articleGenerationReplacementRequestBudgetLimit(env)

--- a/tools/article-capacity-resume.test.js
+++ b/tools/article-capacity-resume.test.js
@@ -905,6 +905,53 @@ test("article generation request budget reserves one bounded replacement topic a
   assert.equal(hooks.articleGenerationRequestBudgetLimit({ ARTICLE_GENERATION_REQUEST_BUDGET: "100" }), 12);
 });
 
+test("the minimum viable rotation gate cannot stop an article already in progress", async () => {
+  const kv = makeKvMock();
+  const env = {
+    BLOG_AI_KV: kv,
+    ARTICLE_GENERATION_DAILY_REQUEST_BUDGET: "34",
+  };
+  const date = new Date();
+  const fingerprint = hooks.articleGenerationSourceFingerprint(
+    "2019 El Paso Walmart shooting",
+    "grounded source material",
+  );
+  kv.store.set(
+    hooks.articleGenerationJournalKey(date),
+    JSON.stringify({
+      version: 1,
+      slug: hooks.articleGenerationJournalKey(date).replace(
+        "article-generation-v1:",
+        "",
+      ),
+      sourceFingerprint: fingerprint,
+      budgetSourceFingerprint: fingerprint,
+      chunks: { brief: { eventTitle: "2019 El Paso Walmart shooting" } },
+      requestBudget: {
+        date: new Date().toISOString().slice(0, 10),
+        sourceFingerprint: fingerprint,
+        used: 6,
+        sourceUsed: 6,
+        dailyUsed: 27,
+        calls: { brief: 1 },
+        sourceCalls: { brief: 1 },
+        rotations: 3,
+      },
+    }),
+  );
+  const journal = await hooks.loadArticleGenerationJournal(
+    env,
+    date,
+    fingerprint,
+  );
+  const result = await hooks
+    .createArticleGenerationCheckpointer(env, date, journal)
+    .consumeRequest("resume analysis");
+  assert.equal(result.used, 7);
+  assert.equal(result.dailyUsed, 28);
+  assert.equal(result.dailyLimit, 34);
+});
+
 test("only repeated-opening continuity failures may degrade gracefully", () => {
   const repeatedOpening = {
     ok: false,


### PR DESCRIPTION
## What changed

- apply the eight-call minimum only when opening a new topic rotation
- let an already-started, checkpointed article consume the remaining date-wide budget
- add a regression matching the live August 3 state: six source calls used, 27/34 daily calls used, and seven remaining

## Root cause

The minimum-viable-rotation guard correctly required eight available calls before starting another topic, but it re-evaluated the same threshold before every later call. The fresh El Paso article started with 13 calls available, checkpointed six calls, then was incorrectly stopped when seven remained.

## Validation

- 565 route/schema tests passed
- 27 focused capacity tests passed
- JavaScript syntax and `git diff --check` passed
- Blog Worker dry-run passed at 1029.55 KiB / 258.26 KiB gzip
