### PR TITLE
Repair copied body sentences locally

### DIFF
--- a/js/blog-ai-worker.js
+++ b/js/blog-ai-worker.js
@@ -16254,6 +16254,105 @@ function isLowRiskChunkedContinuityFailure(continuity) {
   );
 }
 
+// When a later body chunk copies complete sentences from an earlier chunk,
+// deletion is safer than another generative rewrite: it cannot introduce a
+// claim, alter a number, or weaken grounding. Accept the mechanical result
+// only when the later section still has at least one substantive paragraph,
+// the complete article remains above its body floor, and the full continuity
+// audit becomes clean. Otherwise return null and keep the existing AI repair.
+function mechanicallyPruneRepeatedBodySentences(content, continuity) {
+  if (
+    !(continuity?.issues || []).some((issue) =>
+      String(issue || "").startsWith("body cross-section duplicate:")
+    )
+  ) {
+    return null;
+  }
+  const requestedFields = (continuity?.repairFields || [])
+    .filter((field) => ARTICLE_BODY_FIELDS.includes(field))
+    .sort(
+      (left, right) =>
+        ARTICLE_BODY_FIELDS.indexOf(left) - ARTICLE_BODY_FIELDS.indexOf(right),
+    );
+  if (requestedFields.length === 0) return null;
+
+  let candidate = content;
+  const repairedFields = {};
+  let droppedSentenceCount = 0;
+  for (const field of requestedFields) {
+    const fieldIndex = ARTICLE_BODY_FIELDS.indexOf(field);
+    const earlierSentenceKeys = new Set(
+      ARTICLE_BODY_FIELDS
+        .slice(0, fieldIndex)
+        .flatMap((earlierField) =>
+          (candidate?.[earlierField] || []).flatMap((paragraph) =>
+            splitSentences(paragraph, 20)
+          )
+        )
+        .map(normalizeForCompare)
+        .filter(Boolean),
+    );
+    if (earlierSentenceKeys.size === 0) continue;
+
+    const currentParagraphs = Array.isArray(candidate?.[field])
+      ? candidate[field]
+      : [];
+    const retainedParagraphs = [];
+    let fieldDropped = 0;
+    for (const paragraph of currentParagraphs) {
+      const retainedSentences = splitSentences(paragraph, 20).filter(
+        (sentence) => {
+          const key = normalizeForCompare(sentence);
+          if (key && earlierSentenceKeys.has(key)) {
+            fieldDropped += 1;
+            return false;
+          }
+          return Boolean(key);
+        },
+      );
+      const retainedParagraph = retainedSentences.join(" ").trim();
+      if (retainedParagraph) retainedParagraphs.push(retainedParagraph);
+    }
+    if (fieldDropped === 0) continue;
+
+    let replacement = retainedParagraphs;
+    if (
+      replacement.some(
+        (paragraph) => wordCount(paragraph) < CHUNKED_BODY_PARAGRAPH_MIN_WORDS,
+      )
+    ) {
+      const mergedRemainder = replacement.join(" ").trim();
+      replacement = wordCount(mergedRemainder) >=
+          CHUNKED_BODY_PARAGRAPH_MIN_WORDS
+        ? [mergedRemainder]
+        : [];
+    }
+    if (replacement.length === 0) return null;
+
+    const nextCandidate = { ...candidate, [field]: replacement };
+    try {
+      validateChunkedArticleBodyChunk(
+        nextCandidate,
+        [field],
+        "mechanical body duplicate repair",
+      );
+    } catch {
+      return null;
+    }
+    if (articleBodyWordCount(nextCandidate) < MIN_REAL_ARTICLE_BODY_WORDS) {
+      return null;
+    }
+    candidate = nextCandidate;
+    repairedFields[field] = replacement;
+    droppedSentenceCount += fieldDropped;
+  }
+
+  if (droppedSentenceCount === 0) return null;
+  const repairedAudit = auditChunkedArticleContinuity(candidate);
+  if (!repairedAudit.ok) return null;
+  return { repairedFields, droppedSentenceCount };
+}
+
 async function repairChunkedArticleContinuity(
   env,
   model,
@@ -16316,10 +16415,25 @@ ${fieldGuidance}
         fields,
         "chunked article continuity repair",
       );
-      const repairedAudit = auditChunkedArticleContinuity({
+      let repairedCandidate = {
         ...content,
         ...parsed,
-      });
+      };
+      let repairedAudit = auditChunkedArticleContinuity(repairedCandidate);
+      if (!repairedAudit.ok) {
+        const mechanicalRepair = mechanicallyPruneRepeatedBodySentences(
+          repairedCandidate,
+          repairedAudit,
+        );
+        if (mechanicalRepair) {
+          Object.assign(parsed, mechanicalRepair.repairedFields);
+          repairedCandidate = { ...content, ...parsed };
+          repairedAudit = auditChunkedArticleContinuity(repairedCandidate);
+          console.warn(
+            `Blog: removed ${mechanicalRepair.droppedSentenceCount} exact sentence duplicate(s) from continuity-repair output; no second repair call used.`,
+          );
+        }
+      }
       if (!repairedAudit.ok) {
         throw new Error(
           `chunked article continuity repair: ${repairedAudit.issues.join("; ")}`,
@@ -17557,6 +17671,37 @@ Requirements:
     ...analysis,
   }, date);
   let continuity = auditChunkedArticleContinuity(merged);
+  if (!continuity.ok && continuity.repairFields.length > 0) {
+    const mechanicalRepair = mechanicallyPruneRepeatedBodySentences(
+      merged,
+      continuity,
+    );
+    if (mechanicalRepair) {
+      Object.assign(merged, mechanicalRepair.repairedFields);
+      if (
+        mechanicalRepair.repairedFields.overviewParagraphs ||
+        mechanicalRepair.repairedFields.eyewitnessOrChronicle
+      ) {
+        await generationCheckpoint.save("bodyA", {
+          overviewParagraphs: merged.overviewParagraphs,
+          eyewitnessOrChronicle: merged.eyewitnessOrChronicle,
+        });
+      }
+      if (
+        mechanicalRepair.repairedFields.aftermathParagraphs ||
+        mechanicalRepair.repairedFields.conclusionParagraphs
+      ) {
+        await generationCheckpoint.save("bodyB", {
+          aftermathParagraphs: merged.aftermathParagraphs,
+          conclusionParagraphs: merged.conclusionParagraphs,
+        });
+      }
+      continuity = auditChunkedArticleContinuity(merged);
+      console.warn(
+        `Blog: removed ${mechanicalRepair.droppedSentenceCount} exact cross-section duplicate sentence(s) from retained body prose; no repair call used.`,
+      );
+    }
+  }
   if (!continuity.ok && continuity.repairFields.length > 0) {
     console.warn(
       `Blog: repairing chunked continuity fields [${continuity.repairFields.join(", ")}] — ${continuity.issues.join("; ")}`,
@@ -24713,6 +24858,7 @@ export const __contentGenerationTestHooks = {
   prioritizeDedicatedEventSourceCandidates,
   auditChunkedArticleContinuity,
   isLowRiskChunkedContinuityFailure,
+  mechanicallyPruneRepeatedBodySentences,
   repairChunkedArticleContinuity,
   articleGenerationJournalKey,
   articleGenerationSourceFingerprint,

--- a/tools/article-capacity-resume.test.js
+++ b/tools/article-capacity-resume.test.js
@@ -1221,6 +1221,105 @@ test("chunk continuity catches copied body sentences before enrichment", () => {
   assert.equal(hooks.isLowRiskChunkedContinuityFailure(audit), false);
 });
 
+test("exact later-section copies are removed locally when a substantive conclusion remains", async () => {
+  const repeated =
+    "In 2025, Patrick Crusius pleaded guilty to state charges and received a life sentence without parole in El Paso.";
+  const paragraph = (section) =>
+    Array.from(
+      { length: 9 },
+      (_, index) =>
+        `${section} record ${index + 1} identifies Patrick Crusius, El Paso, the 2019 Walmart attack, and a documented stage of the federal or state proceedings.`,
+    ).join(" ");
+  const conclusion = (section) =>
+    `The ${section.toLowerCase()} begins with a distinct review of the documented El Paso record. ${repeated} ${paragraph(section)}`;
+  const content = {
+    title: "2019 El Paso Walmart Shooting — August 3, 2019",
+    eventTitle: "2019 El Paso Walmart shooting",
+    historicalDate: "August 3, 2019",
+    historicalYear: 2019,
+    location: "El Paso, Texas",
+    organizerName: "Patrick Crusius",
+    sourceFacts: [
+      "The Walmart attack occurred in El Paso in 2019.",
+      "Patrick Crusius later faced federal and state proceedings.",
+    ],
+    overviewParagraphs: [
+      paragraph("Overview first"),
+      paragraph("Overview second"),
+    ],
+    eyewitnessOrChronicle: [
+      paragraph("Chronicle first"),
+      paragraph("Chronicle second"),
+    ],
+    aftermathParagraphs: [
+      `The first aftermath passage follows the separate state proceedings in El Paso. ${repeated} ${paragraph("Aftermath first")}`,
+      paragraph("Aftermath second"),
+    ],
+    conclusionParagraphs: [
+      conclusion("Conclusion first"),
+      conclusion("Conclusion second"),
+    ],
+  };
+
+  const before = hooks.auditChunkedArticleContinuity(content);
+  assert.equal(before.ok, false);
+  assert.match(before.issues.join(" "), /body cross-section duplicate/);
+
+  const repaired = hooks.mechanicallyPruneRepeatedBodySentences(
+    content,
+    before,
+  );
+  assert.ok(repaired, "a grounded 110+ word remainder should be repairable without AI");
+  assert.equal(repaired.droppedSentenceCount, 2);
+  assert.equal(
+    hooks.auditChunkedArticleContinuity({
+      ...content,
+      ...repaired.repairedFields,
+    }).ok,
+    true,
+  );
+  assert.ok(
+    repaired.repairedFields.conclusionParagraphs.every(
+      (value) => !value.includes(repeated),
+    ),
+  );
+
+  let repairCalls = 0;
+  const acceptedRepair = await hooks.repairChunkedArticleContinuity(
+    {},
+    "test-model",
+    content,
+    "source-grounded context",
+    {
+      title: content.title,
+      eventTitle: content.eventTitle,
+      historicalDate: content.historicalDate,
+      historicalYear: content.historicalYear,
+      location: content.location,
+      organizerName: content.organizerName,
+      sourceFacts: content.sourceFacts,
+    },
+    before,
+    async (_env, _model, _label, _prompt, _maxTokens, validate) => {
+      repairCalls += 1;
+      const parsed = {
+        conclusionParagraphs: [...content.conclusionParagraphs],
+      };
+      validate(parsed);
+      return parsed;
+    },
+  );
+  assert.equal(repairCalls, 1);
+  assert.equal(
+    hooks.auditChunkedArticleContinuity({
+      ...content,
+      ...acceptedRepair,
+    }).ok,
+    true,
+    "duplicate output from the repair provider must be cleaned before validation rejects it",
+  );
+});
+
 test("source attribution and beyond-Wikipedia rationale are article-level quality signals", () => {
   const body = {
     eventTitle: "A Documented Event",


### PR DESCRIPTION
## What changed

- Detect exact sentences copied by a later generated body section from an earlier section.
- Remove only those exact later copies before spending a generative repair call.
- Apply the same cleanup inside continuity-repair validation when the provider's attempted rewrite repeats retained prose.
- Accept cleanup only when at least one 110+ word paragraph remains, the complete body stays above 750 words, and the full continuity audit passes.
- Persist accepted body checkpoints so later invocations reuse the clean version.

## Root cause

After the August 3 facts checkpoint was repaired, the conclusion continuity rewrite copied seven complete aftermath sentences. The existing validator rejected that output correctly, but it had no safe local recovery path and therefore stranded the otherwise complete retained article.

## Impact

Exact provider copying no longer consumes a second repair attempt or blocks publication when deletion leaves a substantive grounded section. No new prose or facts are manufactured, and every existing body, continuity, and final grounding gate remains active.

## Validation

- `node --check js/blog-ai-worker.js`
- `node --test tests/routes.test.js tests/schema.test.js` — 567 passed
- `node --test tools/article-capacity-resume.test.js tools/article-source-capacity.test.js tools/article-groq-work-distribution.test.js` — 41 passed
- `git diff --check`
- `npx wrangler deploy --dry-run --config wrangler-blog.jsonc` — 1036.76 KiB / 259.86 KiB gzip
