### PR TITLE
Scope grounding checks to real claims

### DIFF
--- a/js/blog-ai-worker.js
+++ b/js/blog-ai-worker.js
@@ -18876,6 +18876,13 @@ const GROUNDING_LEGISLATIVE_KILL_PATTERN =
   /\bkill(?:ed|s|ing)?\s+(?:(?:the|an?)\s+)?(?:entire\s+)?(?:bill|legislation|measure|package|proposal|amendment)\b/gi;
 const GROUNDING_EXPLICIT_CAUSAL_DENIAL_PATTERN =
   /^\s*(?:the\s+)?(?:available\s+)?(?:source|sources|record|records|evidence|source material)\b[\s\S]{0,320}\b(?:does|do|did)\s+not\b[\s\S]{0,240}\b(?:claim|establish|show|demonstrate|prove|state|attribute)\b[\s\S]{0,180}\b(?:because(?:\s+of)?|caus(?:e[ds]?|ing)|due to|lead(?:s|ing)? to|led to|result(?:ed|s|ing)? in|trigger(?:ed|s|ing)?)\b/i;
+// An analysis sentence can describe what the retained evidence cannot show,
+// e.g. "the source does not list the victims, which prevents a fuller
+// assessment." That is an epistemic source limitation, not a historical
+// claim that an actor prevented an outcome. Keep genuine preventive claims
+// auditable while excluding only explicit source/record limitation framing.
+const GROUNDING_SOURCE_LIMITATION_PATTERN =
+  /(?:\b(?:source|sources|record|records|evidence|source material)\b[\s\S]{0,240}\b(?:(?:does|do|did|can|could)\s+not|cannot|fail(?:s|ed)?\s+to|omit(?:s|ted|ting)?|without|absence|lack)\b[\s\S]{0,240}\b(?:block(?:ed|s|ing)?|prevent(?:ed|s|ing)?)\b[\s\S]{0,120}\b(?:assess(?:ment)?|evaluat(?:e[ds]?|ing|ion)?|identif(?:y|ied|ying)|interpret(?:ed|ing|ation)?|reconstruct(?:ed|ing|ion)?|understand(?:ing)?|verif(?:y|ied|ying|ication)|view)\b|^\s*(?:this|the|that)\s+(?:absence|lack|omission)\b[\s\S]{0,120}\b(?:block(?:ed|s|ing)?|prevent(?:ed|s|ing)?)\b[\s\S]{0,120}\b(?:assess(?:ment)?|evaluat(?:e[ds]?|ing|ion)?|identif(?:y|ied|ying)|interpret(?:ed|ing|ation)?|reconstruct(?:ed|ing|ion)?|understand(?:ing)?|verif(?:y|ied|ying|ication)|view)\b)/i;
 const GROUNDING_SUPPORT_STOPWORDS = new Set([
   "about", "after", "again", "against", "also", "among", "another", "around",
   "article", "because", "before", "being", "between", "both", "caused", "causes",
@@ -18890,9 +18897,9 @@ const GROUNDING_CLAIM_RISK_RULES = [
   {
     label: "order attribution",
     claim:
-      /\b(?:authori[sz](?:e[ds]?|ing)|command(?:ed|s|ing)?|direct(?:ed|s|ing)?|order(?:ed|s|ing)?)\b/i,
+      /\b(?:authori[sz](?:e[ds]?|ing)|command(?:ed|s|ing)?|direct(?:ed|s|ing)|direct(?=\s+(?:consequence|effect|outcome|result)\b)|order(?:ed|s|ing)?)\b/i,
     support:
-      /\b(?:authori[sz](?:e[ds]?|ing)|command(?:ed|s|ing)?|direct(?:ed|s|ing)?|order(?:ed|s|ing)?)\b/i,
+      /\b(?:authori[sz](?:e[ds]?|ing)|command(?:ed|s|ing)?|direct(?:ed|s|ing)|direct(?=\s+(?:consequence|effect|outcome|result)\b)|order(?:ed|s|ing)?)\b/i,
   },
   {
     label: "perpetrator attribution",
@@ -19151,6 +19158,12 @@ function unsupportedGroundingClaims(content, sourceMaterial) {
         if (
           rule.label === "causal claim" &&
           GROUNDING_EXPLICIT_CAUSAL_DENIAL_PATTERN.test(sentence)
+        ) {
+          continue;
+        }
+        if (
+          rule.label === "preventive outcome" &&
+          GROUNDING_SOURCE_LIMITATION_PATTERN.test(sentence)
         ) {
           continue;
         }

--- a/tools/article-capacity-resume.test.js
+++ b/tools/article-capacity-resume.test.js
@@ -1179,6 +1179,60 @@ test("legislative idiom, causal denials, and optional labels do not strand a com
   assert.equal(hooks.verifyArticleGrounding(repaired.content, source).ok, true);
 });
 
+test("source limitations and direct quotations are not historical outcome or order claims", () => {
+  const source = {
+    pageTitle: "2019 El Paso shooting",
+    text:
+      "On August 3, 2019, Patrick Crusius attacked a Walmart in El Paso, Texas. Twenty three people were killed and twenty two were injured.",
+    sourceExtract:
+      "Federal prosecutors charged Patrick Crusius with hate crimes and firearms offenses. The source describes the gunman, the weapon, and the law enforcement response.",
+  };
+  const content = {
+    eventTitle: "2019 El Paso Walmart shooting",
+    analysisBad: [
+      {
+        title: "Unnamed individual victims",
+        detail:
+          "While the source gives the aggregate numbers of twenty three killed and twenty two injured, it does not list the names of the deceased or injured individuals. This absence prevents a fuller assessment of the individual experiences represented by the aggregate toll.",
+      },
+      {
+        title: "No firsthand accounts",
+        detail:
+          "The source focuses on Patrick Crusius, the manifesto, the weapon, and the law enforcement response, but it does not include any direct quotes or statements from witnesses, survivors, or first responders in El Paso.",
+      },
+    ],
+  };
+  const sourceLimitationGrounding = hooks.verifyArticleGrounding(
+    content,
+    source,
+  );
+  assert.equal(
+    sourceLimitationGrounding.ok,
+    true,
+    sourceLimitationGrounding.reasons.join("; "),
+  );
+
+  const realPreventiveClaim = hooks.verifyArticleGrounding({
+    ...content,
+    analysisBad: [{
+      title: "Unsupported outcome",
+      detail:
+        "The police response prevented another attack by Patrick Crusius in El Paso after the 2019 Walmart shooting.",
+    }],
+  }, source);
+  assert.match(realPreventiveClaim.reasons.join(" "), /unsupported preventive outcome/);
+
+  const realOrderClaim = hooks.verifyArticleGrounding({
+    ...content,
+    analysisBad: [{
+      title: "Unsupported direction",
+      detail:
+        "Patrick Crusius directed the law enforcement response in El Paso after the 2019 Walmart shooting.",
+    }],
+  }, source);
+  assert.match(realOrderClaim.reasons.join(" "), /unsupported order attribution/);
+});
+
 test("chunk continuity catches copied body sentences before enrichment", () => {
   const repeated =
     "The committee record lists the same dated vote and the same participating institutions in full.";


### PR DESCRIPTION
## Summary

- distinguish evidence/source limitations from unsupported historical prevention claims
- stop treating the adjective in `direct quotes` as an order attribution while retaining `direct outcome` and verbal direction checks
- cover the exact El Paso recovery output and prove genuine prevention/direction assertions still fail closed

## Validation

- 567 route/schema tests passed
- 42 article capacity/source/provider tests passed
- JavaScript syntax and diff checks passed
- Blog Worker dry-run bundled successfully at 1037.76 KiB / 260.12 KiB gzip
