### PR TITLE
Repair optional causal tails locally

### DIFF
--- a/js/blog-ai-worker.js
+++ b/js/blog-ai-worker.js
@@ -18882,7 +18882,7 @@ const GROUNDING_EXPLICIT_CAUSAL_DENIAL_PATTERN =
 // claim that an actor prevented an outcome. Keep genuine preventive claims
 // auditable while excluding only explicit source/record limitation framing.
 const GROUNDING_SOURCE_LIMITATION_PATTERN =
-  /(?:\b(?:source|sources|record|records|evidence|source material)\b[\s\S]{0,240}\b(?:(?:does|do|did|can|could)\s+not|cannot|fail(?:s|ed)?\s+to|omit(?:s|ted|ting)?|without|absence|lack)\b[\s\S]{0,240}\b(?:block(?:ed|s|ing)?|prevent(?:ed|s|ing)?)\b[\s\S]{0,120}\b(?:assess(?:ment)?|evaluat(?:e[ds]?|ing|ion)?|identif(?:y|ied|ying)|interpret(?:ed|ing|ation)?|reconstruct(?:ed|ing|ion)?|understand(?:ing)?|verif(?:y|ied|ying|ication)|view)\b|^\s*(?:this|the|that)\s+(?:absence|lack|omission)\b[\s\S]{0,120}\b(?:block(?:ed|s|ing)?|prevent(?:ed|s|ing)?)\b[\s\S]{0,120}\b(?:assess(?:ment)?|evaluat(?:e[ds]?|ing|ion)?|identif(?:y|ied|ying)|interpret(?:ed|ing|ation)?|reconstruct(?:ed|ing|ion)?|understand(?:ing)?|verif(?:y|ied|ying|ication)|view)\b)/i;
+  /(?:\b(?:source|sources|record|records|evidence|source material)\b[\s\S]{0,240}\b(?:(?:does|do|did|can|could)\s+not|cannot|fail(?:s|ed)?\s+to|omit(?:s|ted|ting)?|without|absence|lack)\b[\s\S]{0,240}\b(?:block(?:ed|s|ing)?|prevent(?:ed|s|ing)?)\b[\s\S]{0,120}\b(?:assess(?:ment)?|evaluat(?:e[ds]?|ing|ion)?|identif(?:y|ied|ying)|interpret(?:ed|ing|ation)?|memoriali[sz](?:e[ds]?|ing|ation)|reconstruct(?:ed|ing|ion)?|understand(?:ing)?|verif(?:y|ied|ying|ication)|view)\b|^\s*(?:this|the|that)\s+(?:absence|lack|omission)\b[\s\S]{0,120}\b(?:block(?:ed|s|ing)?|prevent(?:ed|s|ing)?)\b[\s\S]{0,120}\b(?:assess(?:ment)?|evaluat(?:e[ds]?|ing|ion)?|identif(?:y|ied|ying)|interpret(?:ed|ing|ation)?|memoriali[sz](?:e[ds]?|ing|ation)|reconstruct(?:ed|ing|ion)?|understand(?:ing)?|verif(?:y|ied|ying|ication)|view)\b)/i;
 const GROUNDING_SUPPORT_STOPWORDS = new Set([
   "about", "after", "again", "against", "also", "among", "another", "around",
   "article", "because", "before", "being", "between", "both", "caused", "causes",
@@ -19619,6 +19619,55 @@ function mechanicallyRemoveOptionalUnsupportedClaims(content, source) {
                 finding.field,
                 fullText.replace(targetSentence, trimmedSentence),
               );
+            }
+          }
+        }
+      }
+
+      // A provider can append an unsupported causal conclusion to an
+      // otherwise source-grounded sentence (live August 3 example: "and it
+      // prompted discussions about ..."). Trim only that trailing causal
+      // clause. Keep enough prose for the field's existing structural floor;
+      // the candidate is still accepted only when the grounding audit loses
+      // at least one finding.
+      if (!candidate && finding.label === "causal claim") {
+        const fullText = getContentFieldByPath(working, finding.field);
+        if (typeof fullText === "string") {
+          const targetSentence = splitSentences(fullText).find(
+            (sentence) => sentence.slice(0, 240) === finding.sentence,
+          );
+          if (targetSentence) {
+            const trimmedSentence = targetSentence
+              .replace(
+                /,\s*(?:(?:which|and)\s+)?(?:it\s+)?(?:lead(?:s|ing)?\s+to|led\s+to|prompt(?:ed|s|ing)?|result(?:ed|s|ing)?\s+in|trigger(?:ed|s|ing)?)\b[\s\S]*$/i,
+                ".",
+              )
+              .replace(/\s+\./g, ".")
+              .trim();
+            if (
+              trimmedSentence !== targetSentence &&
+              wordCount(trimmedSentence) >= 7
+            ) {
+              const remainingText = fullText
+                .replace(targetSentence, trimmedSentence)
+                .replace(/\s+/g, " ")
+                .trim();
+              const rootField = finding.field.split(/[.[\]]/)[0];
+              const minimumRemainingWords = /^(?:analysisGood|analysisBad)\[\d+\]\.detail$/.test(
+                finding.field,
+              )
+                ? 60
+                : ARTICLE_BODY_FIELDS.includes(rootField)
+                  ? CHUNKED_BODY_PARAGRAPH_MIN_WORDS
+                  : 12;
+              if (wordCount(remainingText) >= minimumRemainingWords) {
+                candidate = JSON.parse(JSON.stringify(working));
+                setContentFieldByPath(
+                  candidate,
+                  finding.field,
+                  remainingText,
+                );
+              }
             }
           }
         }

--- a/tools/article-capacity-resume.test.js
+++ b/tools/article-capacity-resume.test.js
@@ -1193,7 +1193,7 @@ test("source limitations and direct quotations are not historical outcome or ord
       {
         title: "Unnamed individual victims",
         detail:
-          "While the source gives the aggregate numbers of twenty three killed and twenty two injured, it does not list the names of the deceased or injured individuals. This absence prevents a fuller assessment of the individual experiences represented by the aggregate toll.",
+          "While the source gives the aggregate numbers of twenty three killed and twenty two injured it does not list the names of any of the deceased or injured individuals This absence of personal identifiers limits the ability to understand the human impact of the event beyond statistical totals and prevents a more detailed memorialization of those affected",
       },
       {
         title: "No firsthand accounts",
@@ -1231,6 +1231,38 @@ test("source limitations and direct quotations are not historical outcome or ord
     }],
   }, source);
   assert.match(realOrderClaim.reasons.join(" "), /unsupported order attribution/);
+});
+
+test("an unsupported trailing causal clause is removed without thinning the body", () => {
+  const source = {
+    pageTitle: "2019 El Paso Walmart shooting",
+    text:
+      "On August 3, 2019, Patrick Crusius attacked a Walmart in El Paso, Texas.",
+    sourceExtract:
+      "The Federal Bureau of Investigation investigated the manifesto as domestic terrorism and a hate crime. Patrick Crusius received multiple life sentences without parole.",
+  };
+  const content = {
+    aftermathParagraphs: [
+      "Following the arrest and sentencing of Patrick Crusius, the community of El Paso and the broader United States reflected on the tragedy. The shooting was described as the deadliest attack on Latinos in modern American history, underscoring the targeted nature of the violence. The Federal Bureau of Investigation's investigation highlighted the extremist content of the manifesto and the gunman's intent to emulate a high profile hate crime. The case reinforced the FBI's role in addressing domestic terrorism and hate crimes, and it prompted discussions about the monitoring of extremist forums. The legal proceedings, culminating in multiple life sentences without parole, demonstrated the judicial system's response to the crime. The event remains a stark reminder of the impact of white nationalist ideology and the importance of vigilance against hate based violence.",
+    ],
+  };
+
+  const before = hooks.verifyArticleGrounding(content, source);
+  assert.match(before.reasons.join(" "), /unsupported causal claim/);
+
+  const repaired = hooks.mechanicallyRemoveOptionalUnsupportedClaims(
+    content,
+    source,
+  );
+  assert.deepEqual(repaired.repairedFieldPaths, ["aftermathParagraphs[0]"]);
+  assert.doesNotMatch(
+    repaired.content.aftermathParagraphs[0],
+    /prompted discussions/i,
+  );
+  assert.ok(
+    repaired.content.aftermathParagraphs[0].split(/\s+/).length >= 110,
+  );
+  assert.equal(hooks.verifyArticleGrounding(repaired.content, source).ok, true);
 });
 
 test("chunk continuity catches copied body sentences before enrichment", () => {


### PR DESCRIPTION
## Summary

- recognize source-record limitations involving memorialization as epistemic analysis, not a historical prevention claim
- remove only an unsupported trailing causal clause when the retained paragraph remains above its structural word floor
- keep all grounding rules and full publication gates unchanged

## Production-data proof

The retained August 3 El Paso article passes continuity, grounding, semantics, direct citations, evidence-map, Did You Know, date, curiosity-title, and required-block checks after deterministic repair. It remains 849 body words with six Quick Facts, five Did You Know cards, and three positive plus three critical analysis items.

## Validation

- 567 route/schema tests passed
- 43 article capacity/source/provider tests passed
- JavaScript syntax and diff checks passed
- Blog Worker dry-run bundled at 1039.28 KiB / 260.25 KiB gzip
