### PR TITLE
Skip repair calls for clean bounded drafts

### DIFF
--- a/js/blog-ai-worker.js
+++ b/js/blog-ai-worker.js
@@ -10559,6 +10559,16 @@ async function enrichPublishedPost(
     if (repaired !== content) {
       await persistBoundedRepair(repaired, "content-rationale-mechanical");
     }
+    let boundedIssues = [
+      ...scanBannedPhrases(repaired),
+      ...scanArticleQuality(repaired),
+      ...scanIntraPageDuplication(repaired),
+    ];
+    if (boundedIssues.length === 0) {
+      console.log(
+        `Blog: bounded recovery core for ${slug} is already clean; skipping provider repair passes.`,
+      );
+    } else {
     repaired = await repairRepeatedBodySections(
       env,
       repaired,
@@ -10599,7 +10609,7 @@ async function enrichPublishedPost(
         await persistBoundedRepair(repaired, "quality-pass-1");
       }
     }
-    let boundedIssues = [
+    boundedIssues = [
       ...scanBannedPhrases(repaired),
       ...scanArticleQuality(repaired),
       ...scanIntraPageDuplication(repaired),
@@ -10655,6 +10665,7 @@ async function enrichPublishedPost(
         ...scanArticleQuality(repaired),
         ...scanIntraPageDuplication(repaired),
       ];
+    }
     }
     const BOUNDED_ISSUE_BLOCK_THRESHOLD = 3;
     if (boundedIssues.length > BOUNDED_ISSUE_BLOCK_THRESHOLD) {


### PR DESCRIPTION
## Summary

- run bounded quality scans immediately after deterministic source strengthening
- skip repeated-body and provider quality repair passes when the strengthened core has zero issues
- preserve the existing repair sequence for drafts that still have actionable issues

## Incident proof

The retained August 3 draft has zero bounded issues after deterministic source strengthening. The former unconditional provider repair path then hit Cloudflare 1102; this fast path sends that clean draft directly to factual grounding and save.

## Validation

- 567 route/schema tests passed
- 44 article capacity/source/provider tests passed
- JavaScript syntax and diff checks passed
- Blog Worker dry-run bundled at 1042.64 KiB / 260.95 KiB gzip
