### PR TITLE
Skip timeline work for core drafts

### DIFF
--- a/js/blog-ai-worker.js
+++ b/js/blog-ai-worker.js
@@ -8532,6 +8532,14 @@ async function generateLearningBlocks(env, content) {
 }
 
 function groundLearningBlocks(content) {
+  // Timeline is optional post-publish enrichment. Most core drafts do not
+  // carry one, so avoid constructing and normalizing the full body + evidence
+  // corpus only to discover there is nothing to filter. On the Free Workers
+  // CPU limit this unnecessary pass consumed the remaining budget after a
+  // clean bounded preflight (August 3, 2026).
+  if (!Array.isArray(content?.timeline) || content.timeline.length === 0) {
+    return;
+  }
   const sourceMaterial = sourceMaterialForGrounding(
     groundingSourceFromContent(content),
   );
@@ -25094,6 +25102,7 @@ export const __contentGenerationTestHooks = {
   validateContentDateForPublish,
   validateDirectCitationsForPublish,
   validateSourcedTimelineForPublish,
+  groundLearningBlocks,
   ensureAutomaticTimelineForPublish,
   validateOriginalValueForPublish,
   buildArticleEntityStrip,

--- a/tools/article-capacity-resume.test.js
+++ b/tools/article-capacity-resume.test.js
@@ -1328,6 +1328,16 @@ test("bounded recovery strengthens short core modules from retained sources", ()
   assert.deepEqual(residual, []);
 });
 
+test("timeline grounding skips the evidence corpus when no timeline exists", () => {
+  const coreDraft = {
+    overviewParagraphs: ["A complete core article paragraph."],
+    get sourcePages() {
+      throw new Error("source pages must not be inspected without a timeline");
+    },
+  };
+  assert.doesNotThrow(() => hooks.groundLearningBlocks(coreDraft));
+});
+
 test("chunk continuity catches copied body sentences before enrichment", () => {
   const repeated =
     "The committee record lists the same dated vote and the same participating institutions in full.";


### PR DESCRIPTION
## Summary

- return immediately from timeline grounding when a core draft has no timeline
- avoid building and normalizing the full body/evidence corpus for absent optional enrichment
- retain the complete existing grounding path whenever timeline entries exist

## Live-tail evidence

The August 3 bounded request completed a zero-issue preflight and then hit the 20 ms CPU ceiling immediately after `pre-learning-blocks`. The retained draft has no timeline. This change removes that unnecessary optional pass from the core publication path.

## Validation

- 567 route/schema tests passed
- 45 article capacity/source/provider tests passed
- regression proves source pages are not inspected without a timeline
- JavaScript syntax and diff checks passed
- Blog Worker dry-run bundled at 1042.75 KiB / 260.98 KiB gzip
