### PR TITLE
Harden YouTube topic review and enrichment timing

### DIFF
--- a/.github/workflows/blog-failsafe.yml
+++ b/.github/workflows/blog-failsafe.yml
@@ -1,7 +1,8 @@
 name: Blog Post Failsafe
 
-# Runs after the blog worker's 00:05 prepare, 00:10 generate, and 00:15 enrich
-# invocations. Checks whether the complete pipeline produced a post.
+# Runs after the blog worker's 00:05 prepare, 00:10 generate, 00:15 core
+# publication, and 00:16 post-publish enrichment invocations. Checks whether
+# the complete pipeline produced a post.
 # Checks if today's post actually exists in KV. If it doesn't (the worker
 # failed), this workflow prepares the source, creates a draft, and enriches it
 # in three separate Worker invocations.
@@ -183,4 +184,21 @@ jobs:
           if [ "$POST_FOUND" != "true" ]; then
             echo "::error::post:${SLUG} still missing in KV after 10 minutes. Enrichment likely failed — check Worker logs."
             exit 1
+          fi
+
+          # ── Phase 5: Start optional enrichment after publication ─────────
+          # The verification loop above waits at least one minute after the
+          # synchronous core publication. Give timeline, figures, quiz,
+          # entities, and the evergreen card their own fresh Worker invocation.
+          # This work is optional: a transient failure must not turn an already
+          # public core article into a failed workflow. The 00:50/hourly :55
+          # scheduled passes retain the outbox and retry it safely.
+          echo "Starting post-publish enrichment for ${SLUG}..."
+          RECOVERY_HTTP_STATUS=$(curl -sS --max-time 300 -o /tmp/post-publish-enrichment.json -w "%{http_code}" \
+            -X POST "$WORKER_URL/blog/recover-post-figures?slug=${SLUG}" \
+            -H "Authorization: Bearer ${{ secrets.PUBLISH_SECRET }}" || true)
+          RECOVERY_BODY=$(cat /tmp/post-publish-enrichment.json 2>/dev/null || true)
+          echo "Post-publish enrichment response (HTTP ${RECOVERY_HTTP_STATUS:-000}): ${RECOVERY_BODY}"
+          if [ "$RECOVERY_HTTP_STATUS" != "200" ]; then
+            echo "::warning::Post-publish enrichment remains queued for the scheduled recovery pass."
           fi

--- a/.github/workflows/youtube-upload.yml
+++ b/.github/workflows/youtube-upload.yml
@@ -8,8 +8,27 @@ on:
   schedule:
     - cron: "0 13 * * 1,2,4,5"
 
-  # Allow a manual run from the Actions tab (e.g. to back-fill or re-upload)
+  # Manual reuploads are always private first. A separate reviewed-promotion
+  # mode rechecks the stored narration audit before changing YouTube privacy.
   workflow_dispatch:
+    inputs:
+      mode:
+        description: "Upload privately for review, or promote an audited review upload"
+        required: true
+        type: choice
+        default: upload-private
+        options:
+          - upload-private
+          - promote-reviewed
+      slug:
+        description: "Blog slug, for example 3-august-2026"
+        required: true
+        type: string
+      confirm_topic_review:
+        description: "Required only for promote-reviewed: confirm the narration facts were inspected"
+        required: false
+        type: boolean
+        default: false
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -58,7 +77,14 @@ jobs:
       - name: Install npm dependencies
         run: npm ci
 
+      - name: Run narration topic-safety tests
+        run: |
+          node --check index.js
+          node --check promote-reviewed.js
+          node test-video-text.js
+
       - name: Upload new posts to YouTube
+        if: github.event_name != 'workflow_dispatch' || inputs.mode == 'upload-private'
         run: node index.js
         env:
           CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
@@ -70,9 +96,12 @@ jobs:
           ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
           ELEVENLABS_API_KEY_2: ${{ secrets.ELEVENLABS_API_KEY_2 }}
           ELEVENLABS_API_KEY_3: ${{ secrets.ELEVENLABS_API_KEY_3 }}
-          YOUTUBE_PRIVACY: ${{ secrets.YOUTUBE_PRIVACY }}
+          # Every public upload is staged privately in code. Force manual
+          # reuploads private even if the scheduled channel uses another mode.
+          YOUTUBE_PRIVACY: ${{ github.event_name == 'workflow_dispatch' && 'private' || secrets.YOUTUBE_PRIVACY }}
+          HOLD_FOR_TOPIC_REVIEW: ${{ github.event_name == 'workflow_dispatch' && 'true' || 'false' }}
           ALLOW_SILENT_VIDEO: ${{ secrets.ALLOW_SILENT_VIDEO }}
-          REUPLOAD_SLUGS: ${{ secrets.REUPLOAD_SLUGS }}
+          REUPLOAD_SLUGS: ${{ github.event_name == 'workflow_dispatch' && inputs.slug || secrets.REUPLOAD_SLUGS }}
           MAX_UPLOADS_PER_RUN: ${{ secrets.MAX_UPLOADS_PER_RUN }}
           BLOG_WORKER_URL: ${{ secrets.BLOG_WORKER_URL }}
           YOUTUBE_REGEN_SECRET: ${{ secrets.YOUTUBE_REGEN_SECRET }}
@@ -94,3 +123,18 @@ jobs:
           META_IG_USER_ID: ${{ secrets.META_IG_USER_ID }}
           TIKTOK_ACCESS_TOKEN: ${{ secrets.TIKTOK_ACCESS_TOKEN }}
           TIKTOK_OPEN_ID: ${{ secrets.TIKTOK_OPEN_ID }}
+          META_SKIP_FACEBOOK: ${{ github.event_name == 'workflow_dispatch' && 'true' || '' }}
+          TIKTOK_SKIP: ${{ github.event_name == 'workflow_dispatch' && 'true' || '' }}
+
+      - name: Promote reviewed video to public
+        if: github.event_name == 'workflow_dispatch' && inputs.mode == 'promote-reviewed'
+        run: node promote-reviewed.js
+        env:
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CF_KV_NAMESPACE_ID: ${{ secrets.CF_KV_NAMESPACE_ID }}
+          YOUTUBE_CLIENT_ID: ${{ secrets.YOUTUBE_CLIENT_ID }}
+          YOUTUBE_CLIENT_SECRET: ${{ secrets.YOUTUBE_CLIENT_SECRET }}
+          YOUTUBE_REFRESH_TOKEN: ${{ secrets.YOUTUBE_REFRESH_TOKEN }}
+          PROMOTE_SLUG: ${{ inputs.slug }}
+          PROMOTE_CONFIRM_TOPIC_REVIEW: ${{ inputs.confirm_topic_review }}

--- a/js/blog-ai-worker.js
+++ b/js/blog-ai-worker.js
@@ -667,20 +667,26 @@ const EVERY_OTHER_DAYS = 1; // Generate every N days
 // scheduled invocations. Generation has no same-night retry minute: durable
 // provider circuits and the chunk journal let the 00:35 failsafe resume safely
 // instead of launching overlapping or quota-draining retries.
-const DAILY_PUBLICATION_CRON = "5,10,15 0 * * *";
+const DAILY_PUBLICATION_CRON = "5,10,15,16 0 * * *";
 const DRAFT_PREPARATION_MINUTES = new Set([5]);
 const DRAFT_GENERATION_MINUTES = new Set([10]);
 const DRAFT_ENRICHMENT_MINUTES = new Set([15]);
+// The 00:15 phase publishes the validated factual core and stores the
+// post-publish outbox. Give optional timeline/figure/quiz/entity work a fresh
+// invocation one minute later instead of waiting for the hourly :55 pass.
+// :50 and :55 remain bounded retries when publication runs long or a provider
+// is temporarily unavailable.
+const POST_PUBLISH_RECOVERY_MINUTES = new Set([16]);
 const WORKERS_AI_GENERATION_MINUTES = new Set();
-// Entity recovery has one isolated midnight invocation. Evergreen recovery is
-// handled by the hourly :55 trigger below, including 00:55; keeping 00:55 in
-// both expressions would race two maintenance invocations against the same
-// article and provider/KV budget.
+// Entity recovery has one isolated midnight invocation. The current article's
+// first evergreen/outbox attempt is 00:16; the hourly :55 trigger below is its
+// retry. Keeping 00:55 in the entity expression would still race two
+// maintenance invocations against the same article and provider/KV budget.
 const RECOVERY_CRON = "50 0 * * *";
 const ENTITY_RECOVERY_MINUTE = 50;
 // A second isolated invocation repairs at most one older pending companion.
 // Keeping backlog work separate prevents an old failure from displacing the
-// current day's required edition at 00:55.
+// current day's one-minute post-publish attempt or its 00:55 retry.
 const EVERGREEN_HISTORY_BACKLOG_CRON = "25 1 * * *";
 // Retry only the current day's still-pending companion after provider
 // cooldowns. These invocations are GET-only when the queue is empty and never
@@ -771,6 +777,9 @@ function scheduledBlogPhase(cron, scheduledMinute) {
     if (DRAFT_PREPARATION_MINUTES.has(scheduledMinute)) return "prepare";
     if (DRAFT_GENERATION_MINUTES.has(scheduledMinute)) return "generate";
     if (DRAFT_ENRICHMENT_MINUTES.has(scheduledMinute)) return "enrich";
+    if (POST_PUBLISH_RECOVERY_MINUTES.has(scheduledMinute)) {
+      return "post-publish-recovery";
+    }
     return "ignore";
   }
   if (cron === RECOVERY_CRON) {
@@ -3963,7 +3972,13 @@ export default {
           }
           return;
         }
-        if (phase === "history-recovery") {
+        // The daily 00:16 invocation is the normal first attempt, one minute
+        // after the 00:15 core-publication slot. The hourly :55 invocation is
+        // the same idempotent current-day recovery path and remains a retry.
+        if (
+          phase === "post-publish-recovery" ||
+          phase === "history-recovery"
+        ) {
           const guarded = await prepareBlogKvBudget(env, "maintenance");
           if (!guarded.budget.allowPhase) return;
           const scheduledDate = Number.isFinite(Number(event?.scheduledTime))

--- a/tools/article-capacity-resume.test.js
+++ b/tools/article-capacity-resume.test.js
@@ -1563,9 +1563,14 @@ test("failsafe permits one recovery attempt and has a non-overlapping concurrenc
       .length,
     1,
   );
+  assert.match(
+    workflow,
+    /\/blog\/recover-post-figures\?slug=\$\{SLUG\}/,
+    "a failsafe publication must start optional enrichment after its one-minute verification wait",
+  );
 });
 
-test("Evergreen maintenance has one 00:55 trigger instead of a duplicate midnight race", () => {
+test("post-publish enrichment starts at 00:16 and retains one hourly retry trigger", () => {
   const worker = readFileSync(
     new URL("../js/blog-ai-worker.js", import.meta.url),
     "utf8",
@@ -1575,12 +1580,15 @@ test("Evergreen maintenance has one 00:55 trigger instead of a duplicate midnigh
     "utf8",
   );
 
+  assert.match(worker, /const DAILY_PUBLICATION_CRON = "5,10,15,16 0 \* \* \*"/);
+  assert.match(worker, /const POST_PUBLISH_RECOVERY_MINUTES = new Set\(\[16\]\)/);
+  assert.match(worker, /return "post-publish-recovery"/);
   assert.match(worker, /const RECOVERY_CRON = "50 0 \* \* \*"/);
   assert.match(worker, /const EVERGREEN_HISTORY_RETRY_CRON = "55 \* \* \* \*"/);
   assert.doesNotMatch(worker, /const RECOVERY_CRON = "50,55 0 \* \* \*"/);
   assert.match(
     wrangler,
-    /"crons": \["5,10,15 0 \* \* \*", "50 0 \* \* \*", "25 1 \* \* \*", "55 \* \* \* \*"\]/,
+    /"crons": \["5,10,15,16 0 \* \* \*", "50 0 \* \* \*", "25 1 \* \* \*", "55 \* \* \* \*"\]/,
   );
   assert.doesNotMatch(wrangler, /50,55 0 \* \* \*/);
 });

--- a/wrangler-blog.jsonc
+++ b/wrangler-blog.jsonc
@@ -67,24 +67,28 @@
   // The main SEO worker (seo-worker.js) keeps handling everything else.
   "routes": [{ "pattern": "thisday.info/blog/*", "zone_name": "thisday.info" }],
 
-  // Cron pipeline — primary publication runs at 00:05/00:10/00:15 UTC.
+  // Cron pipeline — primary publication runs at 00:05/00:10/00:15 UTC,
+  // followed by optional post-publish enrichment at 00:16.
   // 00:05 vets and caches the source package after warmup-worker (00:01).
   // 00:10 generates the lightweight draft from that cache with a fresh
   // external-subrequest budget. There is no immediate generation retry:
   // provider cooldowns persist across invocations and validated article chunks
   // remain resumable for the single 00:35 GitHub failsafe attempt.
   // Blog post is the source of truth for the video narration + metadata.
-  // 00:15 enrichment runs in a separate invocation with a fresh external
+  // 00:15 core enrichment/publication runs in a separate invocation with a fresh external
   // subrequest budget. A bounded rejection blocks that topic but does not
   // regenerate another full article in the same capacity window.
+  // 00:16 uses another fresh invocation for timeline, figures, quiz, entities,
+  // and the evergreen card. This normally completes the optional outbox one
+  // minute after core publication; 00:50 and hourly :55 remain retries.
   // 00:50 runs the dedicated entity-recovery pass (ENTITY_RECOVERY_CRON): a fresh
   // invocation with full subrequest budget re-links any people strips the budget-starved
   // 00:05 generation left unlinked. Must stay after the 00:35 failsafe.
-  // The hourly :55 trigger promotes the daily article's Evergreen companion,
+  // The hourly :55 trigger retries the daily article's Evergreen companion,
   // including at 00:55. It is intentionally not duplicated in the 00:50
   // entity-recovery expression.
   // 01:25 retries at most one older pending companion in a separate invocation,
-  // so backlog repair never displaces the current day's 00:55 edition.
+  // so backlog repair never displaces the current day's immediate edition.
   // :55 hourly retries only today's still-pending companion after provider
   // cooldowns, AND is the pass that fetches inline person/event figures + the
   // quiz for a freshly published post (recoverPublishedPostEnrichment). They
@@ -96,7 +100,7 @@
   // YouTube upload is scheduled separately on Mon/Tue/Thu/Fri at 13:00 UTC
   // (about 09:00 Eastern during daylight saving time).
   "triggers": {
-    "crons": ["5,10,15 0 * * *", "50 0 * * *", "25 1 * * *", "55 * * * *"],
+    "crons": ["5,10,15,16 0 * * *", "50 0 * * *", "25 1 * * *", "55 * * * *"],
   },
 
   // KV namespaces — blog posts/index and shared events/quiz cache.

--- a/youtube-upload/index.js
+++ b/youtube-upload/index.js
@@ -41,12 +41,23 @@ import {
   updateIndexEntry,
   deleteIndexEntry,
 } from "./lib/kv.js";
-import { selectInterestingNarrationFacts } from "./lib/narration-selection.js";
+import {
+  assessNarrationCaptionIntegrity,
+  auditNarrationTopicConnection,
+  buildNarrationTopicContext,
+  selectInterestingNarrationFacts,
+} from "./lib/narration-selection.js";
 import { generateVideo, resolvePostImage } from "./lib/video.js";
 import { videoHeadlineTitle, videoMatchTitle } from "./lib/titles.js";
 import { verifyKvReadWriteAccess } from "./lib/kv.js";
 import { checkVideoQuality } from "./lib/video-quality.js";
-import { uploadToYoutube, verifyYoutubeAuth } from "./lib/youtube.js";
+import {
+  auditYoutubeVideo,
+  getYoutubeVideo,
+  setYoutubeVideoPrivacy,
+  uploadToYoutube,
+  verifyYoutubeAuth,
+} from "./lib/youtube.js";
 import {
   acquireUploadLock,
   getUploaded,
@@ -63,7 +74,6 @@ import { postToMeta } from "./lib/meta.js";
 import { postToTikTok } from "./lib/tiktok.js";
 import {
   generateNarration,
-  buildNarrationScript,
   buildNarrationParts,
 } from "./lib/elevenlabs.js";
 
@@ -154,6 +164,19 @@ async function waitForPublishedPost(slug, {
   return { posts: await getPostIndex(), post: null };
 }
 
+async function waitForYoutubeAudit(post, youtubeId, expectedPrivacy) {
+  let lastAudit = null;
+  for (let attempt = 1; attempt <= 5; attempt += 1) {
+    const video = await getYoutubeVideo(youtubeId);
+    lastAudit = auditYoutubeVideo(post, video, { expectedPrivacy });
+    if (lastAudit.ok) return video;
+    if (attempt < 5) await new Promise((resolve) => setTimeout(resolve, 2_000));
+  }
+  throw new Error(
+    `YOUTUBE_METADATA_MISMATCH: ${lastAudit?.reasons.join("; ") || "video was not readable"}`,
+  );
+}
+
 /**
  * Ensures today's post exists in KV. If not found, calls POST /blog/publish
  * to generate it, waits 60 s for propagation, then returns the refreshed index.
@@ -236,11 +259,16 @@ function ensureSocialPrereqs() {
 
 async function main() {
   const privacyMode = process.env.YOUTUBE_PRIVACY || "public";
+  const holdForTopicReview =
+    process.env.HOLD_FOR_TOPIC_REVIEW === "true";
   const allowSilentVideo = process.env.ALLOW_SILENT_VIDEO === "true";
   const maxUploadsPerRun = 1; // FORCE: Only upload 1 video per run
 
   const todaySlug = getTodaySlug();
   console.log(`YouTube privacy mode: ${privacyMode}`);
+  if (holdForTopicReview) {
+    console.log("Manual topic review hold: enabled");
+  }
   if (allowSilentVideo) {
     console.warn("Warning: ALLOW_SILENT_VIDEO=true — uploads may have no narration.");
   }
@@ -350,11 +378,19 @@ async function main() {
         const wikiArticleUrl = await getPostWikipediaUrl(post.slug).catch(
           () => null,
         );
+        const narrationTopicContext = buildNarrationTopicContext(
+          post,
+          quickFacts,
+        );
         const selectedNarrationItems = selectInterestingNarrationFacts(
           videoMatchTitle(post),
           contentItems,
           articleText,
-          { limit: 3, dateHint: videoHeadlineTitle(post) },
+          {
+            limit: 3,
+            dateHint: videoHeadlineTitle(post),
+            topicContext: narrationTopicContext,
+          },
         );
         if (selectedNarrationItems.length > 0) {
           console.log(
@@ -370,15 +406,65 @@ async function main() {
         }
 
         const narrationItems = selectedNarrationItems;
-
-        const script = buildNarrationScript(
+        const preparedNarrationParts = buildNarrationParts(
           post,
           narrationItems,
+        );
+        // Date trimming can remove the only topic anchor from an otherwise
+        // eligible candidate. Audit the exact post-trim text that TTS will
+        // receive, drop any disconnected part, and require the remaining
+        // script to pass as a whole.
+        const preparedTopicAudit = auditNarrationTopicConnection(
+          videoMatchTitle(post),
+          preparedNarrationParts,
+          narrationTopicContext,
+        );
+        const narrationParts = preparedTopicAudit.results
+          .filter((result) => result.connected)
+          .map((result) => result.text);
+        if (narrationParts.length !== preparedNarrationParts.length) {
+          console.warn(
+            `  ⚠ Dropped ${preparedNarrationParts.length - narrationParts.length} narration fact(s) after the exact TTS-text topic check.`,
+          );
+        }
+        const script = narrationParts.join(" ");
+        const topicAudit = auditNarrationTopicConnection(
+          videoMatchTitle(post),
+          narrationParts,
+          narrationTopicContext,
+        );
+        if (!topicAudit.ok) {
+          const failures = topicAudit.results
+            .filter((result) => !result.connected)
+            .map((result) => `${result.reason}: ${result.text}`)
+            .join(" | ");
+          throw new Error(
+            `NARRATION_TOPIC_MISMATCH: refusing upload for ${post.slug}` +
+              (failures ? ` — ${failures}` : ""),
+          );
+        }
+        const storedTopicAudit = {
+          version: topicAudit.version,
+          checkedAt: new Date().toISOString(),
+          title: topicAudit.title,
+          connected: true,
+          facts: narrationParts,
+          script,
+        };
+        console.log(
+          `  ✓ Narration topic audit passed (${topicAudit.checkedFacts}/${topicAudit.checkedFacts} connected).`,
         );
         const { path: narrPath, words: narrWords } = await generateNarration(
           post.slug,
           script,
         );
+        const captionAudit = assessNarrationCaptionIntegrity(script, narrWords);
+        if (!captionAudit.ok) {
+          throw new Error(
+            `NARRATION_CAPTION_MISMATCH: ${captionAudit.reason}`,
+          );
+        }
+        storedTopicAudit.captionCoverage = captionAudit.coverage;
         narrationPath = narrPath;
         if (!narrationPath && !allowSilentVideo) {
           throw new Error(
@@ -425,10 +511,7 @@ async function main() {
             useAiImage,
             contentItems: selectedNarrationItems,
             wikiArticleUrl,
-            narrationParts: buildNarrationParts(
-              post,
-              narrationItems,
-            ),
+            narrationParts,
             qualityHint,
           });
           videoPath = videoResult.path;
@@ -467,19 +550,79 @@ async function main() {
           console.log(`  ⚠ Already uploaded by a concurrent run — skipping.`);
           continue;
         }
-        console.log("  Uploading to YouTube...");
-        const youtubeId = await uploadToYoutube(videoPath, post, videoCuts);
+        const finalTopicAudit = auditNarrationTopicConnection(
+          videoMatchTitle(post),
+          narrationParts,
+          narrationTopicContext,
+        );
+        const finalCaptionAudit = assessNarrationCaptionIntegrity(
+          script,
+          narrWords,
+        );
+        if (!finalTopicAudit.ok || !finalCaptionAudit.ok) {
+          throw new Error(
+            "PRE_UPLOAD_RECHECK_FAILED: narration topic or captions changed after rendering",
+          );
+        }
+
+        console.log("  Uploading to YouTube as a private review video...");
+        const replacedUpload = freshUploaded[post.slug] || null;
+        const stagedPrivacy = privacyMode === "public" ? "private" : privacyMode;
+        const youtubeId = await uploadToYoutube(videoPath, post, videoCuts, {
+          privacyStatus: stagedPrivacy,
+        });
         console.log(`  ✓ https://www.youtube.com/shorts/${youtubeId}`);
 
+        await waitForYoutubeAudit(post, youtubeId, stagedPrivacy);
+        console.log(
+          `  ✓ YouTube metadata and ${stagedPrivacy} review status verified.`,
+        );
+
+        const requiresManualReview =
+          holdForTopicReview || Boolean(replacedUpload?.youtubeId);
+        let privacy = stagedPrivacy;
+        if (privacyMode === "public" && !requiresManualReview) {
+          const promotionTopicAudit = auditNarrationTopicConnection(
+            videoMatchTitle(post),
+            narrationParts,
+            narrationTopicContext,
+          );
+          const promotionCaptionAudit = assessNarrationCaptionIntegrity(
+            script,
+            narrWords,
+          );
+          if (!promotionTopicAudit.ok || !promotionCaptionAudit.ok) {
+            throw new Error(
+              "PUBLICATION_TOPIC_RECHECK_FAILED: private upload retained for review",
+            );
+          }
+          await setYoutubeVideoPrivacy(youtubeId, "public");
+          await waitForYoutubeAudit(post, youtubeId, "public");
+          privacy = "public";
+          console.log("  ✓ Final topic recheck passed; video is public.");
+        } else if (privacyMode === "public") {
+          console.log(
+            "  ✓ Replacement remains private pending the separate reviewed-promotion pass.",
+          );
+        }
+
         // Record in KV tracker (overwrites previous entry for re-uploads)
-        const privacy = privacyMode;
-        await markUploaded(post.slug, youtubeId, privacy);
+        await markUploaded(post.slug, youtubeId, privacy, {
+          replacesYoutubeId: replacedUpload?.youtubeId || "",
+          topicAudit: storedTopicAudit,
+        });
         console.log(
           `  Tracker updated: youtube:uploaded[${post.slug}] (privacy=${privacy})`,
         );
-        const metaOk = await postToMeta(videoPath, post, youtubeId);
-        const tiktokOk = await postToTikTok(videoPath, post, youtubeId);
-        await markSocialPosted(post.slug, { meta: metaOk, tiktok: tiktokOk });
+        if (privacy === "public") {
+          const metaOk = await postToMeta(videoPath, post, youtubeId);
+          const tiktokOk = await postToTikTok(videoPath, post, youtubeId);
+          await markSocialPosted(post.slug, { meta: metaOk, tiktok: tiktokOk });
+        } else {
+          console.log(
+            `  Review upload is ${privacy}; social publishing is deferred until public promotion.`,
+          );
+        }
         await notifyUpload(post, youtubeId, videoPath);
         await recordPipelineSuccess("youtube");
       } catch (err) {

--- a/youtube-upload/lib/kv.js
+++ b/youtube-upload/lib/kv.js
@@ -137,12 +137,24 @@ export async function getPostContent(slug) {
  * @param {string} slug
  * @returns {Promise<string|null>}
  */
-export async function getArticleText(slug) {
-  const raw = await kvGet(`post:${slug}`);
-  if (!raw) return null;
+export function extractArticleTextFromHtml(raw) {
+  const html = String(raw || "");
+  if (!html) return null;
 
-  const paras = [...raw.matchAll(/<p[^>]*>([\s\S]*?)<\/p>/gi)]
-    .map(([, v]) =>
+  // Current generated posts place the substantive body between these stable
+  // render markers. Scope to it so metadata, Did You Know cards, navigation,
+  // and unrelated recommendation copy cannot become narration fallback text.
+  const bodyStart = html.indexOf("<!-- Overview -->");
+  const bodyEnd = html.indexOf("<!-- Personal Analysis -->", bodyStart + 1);
+  const source = bodyStart >= 0 && bodyEnd > bodyStart
+    ? html.slice(bodyStart, bodyEnd)
+    : html;
+
+  const paras = [...source.matchAll(/<p([^>]*)>([\s\S]*?)<\/p>/gi)]
+    .filter(([, attrs]) =>
+      !/\b(?:article-meta|dyn-fact|tdq-|amazon-|evidence-map)\b/i.test(attrs),
+    )
+    .map(([, , v]) =>
       decodeEntities(
         v
           .replace(/<[^>]+>/g, " ")
@@ -150,10 +162,15 @@ export async function getArticleText(slug) {
           .trim(),
       ),
     )
-    .filter((s) => s.length > 60 && s.length < 800)
+    .filter((s) => s.length > 60 && s.length < 1600)
     .slice(0, 8);
 
-  return paras.length > 0 ? paras.join(" ").slice(0, 2000) : null;
+  return paras.length > 0 ? paras.join(" ").slice(0, 2500) : null;
+}
+
+export async function getArticleText(slug) {
+  const raw = await kvGet(`post:${slug}`);
+  return extractArticleTextFromHtml(raw);
 }
 
 /**

--- a/youtube-upload/lib/narration-selection.js
+++ b/youtube-upload/lib/narration-selection.js
@@ -81,6 +81,68 @@ const INTEREST_PATTERNS = [
   /\b(?:wife|husband|sister|brother|daughter|son|president|queen|king|emperor)\b/i,
 ];
 
+// A sentence can be factually true and still be the wrong subject for the
+// video. This happened on 2026-08-03 when El Paso census/geography passages
+// outranked facts about the Walmart shooting. Reject page-shell noise and
+// generic place profiles before the existing "interestingness" scorer runs.
+const NAVIGATION_NOISE_PATTERNS = [
+  /(?:^|\s)video\s+[^.!?]{5,120}\s+video\s+/i,
+  /\b(?:flights? cancelled|click here|watch live|latest videos?|more stories|related stories)\b/i,
+  /\b(?:newsletter|sign up|subscribe|advertisement)\b/i,
+];
+
+const PLACE_PROFILE_PATTERNS = [
+  /\b(?:county seat|metropolitan area)\b/i,
+  /\b(?:most|least|\d+(?:st|nd|rd|th)-most) populous\b/i,
+  /\bpopulation of\s+[\d,]+\b/i,
+  /\b\d{4} census\b/i,
+  /\bstands? on (?:the )?[^.!?]{0,80}\b(?:border|river)\b/i,
+  /\bis a city in\b/i,
+  /\bacross the .{0,40}\bborder from\b/i,
+  /\b(?:estimated|approximately)\s+[\d,]+\s+residents\b/i,
+];
+
+const EVENT_CONNECTION_PATTERN =
+  /\b(?:adopted|announced|appointed|arrest(?:ed|s)?|attack(?:ed|s)?|awarded|battle|became|began|captur(?:e[ds]?|ing)|charged|coup|crash(?:ed|es)?|created|crowned|decid(?:ed|es)|declared|dedicated|died|disappear(?:ed|s)?|discovered|dissolved|elected|enacted|ended|established|execut(?:ed|es)|fired|fought|founded|gunman|investigat(?:ed|es|ion)|introduced|invaded|issued|kill(?:ed|s)?|landed|launch(?:ed|es)|manifesto|murder(?:ed|s)?|opened|passed|pleaded|prosecut(?:ed|ion)|published|ratified|reached|reign(?:ed|s)?|released|rescu(?:ed|es)|resigned|revolt(?:ed|s)?|salut(?:ed|es|ing)|sentenced|served|shooting|signed|struck|surrender(?:ed|s)?|trial|unveiled|vanish(?:ed|es)|won|wound(?:ed|s)?)\b/i;
+
+const EVENT_ROLE_CONNECTIONS = [
+  {
+    event: /\b(?:attack|kill|massacre|murder|shoot|terror)\w*\b/i,
+    fact: /\b(?:attacker|gunman|killer|perpetrator|shooter|suspect|terrorist)\b/i,
+  },
+  {
+    event: /\b(?:battle|invasion|war)\w*\b/i,
+    fact: /\b(?:army|commander|general|soldier|troops?)\b/i,
+  },
+  {
+    event: /\b(?:elect|election|president|prime minister)\w*\b/i,
+    fact: /\b(?:candidate|president|prime minister|winner)\b/i,
+  },
+];
+
+const TOPIC_GENERIC_TOKENS = new Set([
+  "article",
+  "began",
+  "begins",
+  "city",
+  "county",
+  "date",
+  "event",
+  "figure",
+  "history",
+  "key",
+  "location",
+  "occurred",
+  "occurs",
+  "source",
+  "state",
+  "states",
+  "subject",
+  "united",
+  "year",
+  "years",
+]);
+
 function normalizeText(value) {
   return String(value || "")
     .replace(/&(?:nbsp|amp|quot|apos|#39);/gi, " ")
@@ -165,6 +227,234 @@ function tokenOverlap(left, right) {
   return shared / Math.min(a.size, b.size);
 }
 
+function topicTokenSet(value) {
+  return new Set(
+    narrationTokens(value).filter((token) => !TOPIC_GENERIC_TOKENS.has(token)),
+  );
+}
+
+function quickFactValue(quickFacts, label) {
+  const pattern = new RegExp(`^${label}\\s*:\\s*(.+)$`, "i");
+  for (const value of Array.isArray(quickFacts) ? quickFacts : []) {
+    const match = normalizeText(value).match(pattern);
+    if (match?.[1]) return match[1];
+  }
+  return "";
+}
+
+function topicContextParts(topicContext, title = "") {
+  if (!topicContext || typeof topicContext !== "object") {
+    return {
+      text: normalizeText(topicContext),
+      coreText: normalizeText(title),
+      personTerms: [],
+      locationText: "",
+    };
+  }
+  return {
+    text: normalizeText(topicContext.text),
+    coreText: normalizeText(topicContext.coreText || title),
+    personTerms: Array.isArray(topicContext.personTerms)
+      ? topicContext.personTerms.map(normalizeText).filter(Boolean)
+      : [],
+    locationText: normalizeText(topicContext.locationText),
+  };
+}
+
+/**
+ * Builds a trusted topic context from the post's canonical metadata and
+ * event-bearing Quick Facts. Date/location-only facts are deliberately
+ * excluded so a city profile cannot bootstrap its own relevance.
+ */
+export function buildNarrationTopicContext(post, quickFacts = []) {
+  const factContext = (Array.isArray(quickFacts) ? quickFacts : [])
+    .map((value) => normalizeText(value))
+    .filter((value) =>
+      /^(?:event|key figure|source subject|source detail|confirmed outcome|investigation|trial|decision|record):/i.test(
+        value,
+      ),
+    );
+  const keyTerms = Array.isArray(post?.keyTerms)
+    ? post.keyTerms.map((term) => term?.term).filter(Boolean)
+    : [];
+  const personTerms = Array.isArray(post?.keyTerms)
+    ? post.keyTerms
+        .filter((term) => term?.type === "person")
+        .map((term) => term?.term)
+        .filter(Boolean)
+    : [];
+  const text = [
+    post?.eventTitle,
+    post?.sourcePageTitle,
+    post?.factualTitle,
+    post?.keywords,
+    post?.description,
+    ...keyTerms,
+    ...factContext,
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return {
+    text,
+    coreText: [
+      post?.eventTitle,
+      post?.sourcePageTitle,
+      post?.factualTitle,
+      post?.title,
+    ]
+      .filter(Boolean)
+      .join(" "),
+    personTerms,
+    locationText: [
+      post?.location,
+      quickFactValue(quickFacts, "Location"),
+    ]
+      .filter(Boolean)
+      .join(" "),
+  };
+}
+
+export function narrationTopicConnection(value, title, topicContext = "") {
+  const text = normalizeText(value);
+  if (!text) {
+    return {
+      connected: false,
+      reason: "empty narration fact",
+      titleMatches: [],
+      contextMatches: [],
+      personMatches: [],
+      locationMatches: [],
+    };
+  }
+  if (NAVIGATION_NOISE_PATTERNS.some((pattern) => pattern.test(text))) {
+    return {
+      connected: false,
+      reason: "page navigation or unrelated headline noise",
+      titleMatches: [],
+      contextMatches: [],
+      personMatches: [],
+      locationMatches: [],
+    };
+  }
+  const context = topicContextParts(topicContext, title);
+  const personTokens = topicTokenSet(context.personTerms.join(" "));
+  const locationTokens = topicTokenSet(context.locationText);
+  const backgroundTokens = new Set([...personTokens, ...locationTokens]);
+  const coreTokens = new Set(
+    [...topicTokenSet(`${title} ${context.coreText}`)].filter(
+      (token) => !backgroundTokens.has(token),
+    ),
+  );
+  const contextTokens = new Set(
+    [...topicTokenSet(`${title} ${context.text}`)].filter(
+      (token) => !backgroundTokens.has(token),
+    ),
+  );
+  const factTokens = topicTokenSet(text);
+  const titleMatches = [...factTokens].filter((token) => coreTokens.has(token));
+  const contextMatches = [...factTokens].filter((token) => contextTokens.has(token));
+  const personMatches = [...factTokens].filter((token) => personTokens.has(token));
+  const locationMatches = [...factTokens].filter((token) => locationTokens.has(token));
+  const hasEventConnection = EVENT_CONNECTION_PATTERN.test(text);
+  const compatibleRole = EVENT_ROLE_CONNECTIONS.some(
+    ({ event, fact }) => event.test([...coreTokens].join(" ")) && fact.test(text),
+  );
+  if (
+    PLACE_PROFILE_PATTERNS.some((pattern) => pattern.test(text)) &&
+    titleMatches.length === 0 &&
+    !compatibleRole
+  ) {
+    return {
+      connected: false,
+      reason: "generic place profile",
+      titleMatches,
+      contextMatches,
+      personMatches,
+      locationMatches,
+    };
+  }
+  const connected =
+    titleMatches.length >= 2 ||
+    ((titleMatches.length >= 1 || contextMatches.length >= 1) &&
+      hasEventConnection) ||
+    (contextMatches.length >= 2 && hasEventConnection) ||
+    (personMatches.length >= 1 && (compatibleRole || hasEventConnection));
+
+  return {
+    connected,
+    reason: connected
+      ? "shares canonical topic anchors"
+      : "does not identify the event, its actor, or a documented event action",
+    titleMatches,
+    contextMatches,
+    personMatches,
+    locationMatches,
+  };
+}
+
+export function auditNarrationTopicConnection(
+  title,
+  facts,
+  topicContext = "",
+  { minimumFacts = 2 } = {},
+) {
+  const items = (Array.isArray(facts) ? facts : [])
+    .map((fact) => normalizeText(fact))
+    .filter(Boolean);
+  const results = items.map((text) => ({
+    text,
+    ...narrationTopicConnection(text, title, topicContext),
+  }));
+  return {
+    version: 1,
+    ok:
+      results.length >= minimumFacts &&
+      results.every((result) => result.connected) &&
+      results.some(
+        (result) =>
+          result.titleMatches.length > 0 ||
+          result.personMatches.length > 0 ||
+          result.contextMatches.length >= 2,
+      ),
+    title: normalizeText(title),
+    checkedFacts: results.length,
+    minimumFacts,
+    results,
+  };
+}
+
+export function assessNarrationCaptionIntegrity(script, words) {
+  const expected = narrationTokens(script);
+  const actual = narrationTokens(
+    (Array.isArray(words) ? words : [])
+      .map((entry) => entry?.word || "")
+      .join(" "),
+  );
+  if (expected.length === 0 || actual.length === 0) {
+    return { ok: false, coverage: 0, reason: "caption words are missing" };
+  }
+  const remaining = new Map();
+  for (const token of actual) {
+    remaining.set(token, (remaining.get(token) || 0) + 1);
+  }
+  let matched = 0;
+  for (const token of expected) {
+    const count = remaining.get(token) || 0;
+    if (count <= 0) continue;
+    matched += 1;
+    remaining.set(token, count - 1);
+  }
+  const coverage = matched / expected.length;
+  return {
+    ok: coverage >= 0.9,
+    coverage,
+    reason:
+      coverage >= 0.9
+        ? "caption words match the approved narration"
+        : `caption coverage ${(coverage * 100).toFixed(1)}% is below 90%`,
+  };
+}
+
 function properNounCount(value) {
   return (
     normalizeText(value).match(
@@ -229,17 +519,22 @@ function candidateSentences(items) {
   return candidates;
 }
 
-function scoredCandidates(title, items) {
+function scoredCandidates(title, items, topicContext = "") {
   return candidateSentences(items).map((text, sourceOrder) => ({
     text,
     sourceOrder,
     score: narrationFactScore(text, title),
+    topic: narrationTopicConnection(text, title, topicContext),
   }));
 }
 
-function rankedCandidates(title, items) {
-  return scoredCandidates(title, items)
-    .filter((candidate) => candidate.score >= 4)
+function rankedCandidates(title, items, topicContext = "") {
+  const minimumScore = topicContext ? 3 : 4;
+  return scoredCandidates(title, items, topicContext)
+    .filter(
+      (candidate) =>
+        candidate.score >= minimumScore && candidate.topic.connected,
+    )
     .sort(
       (left, right) =>
         right.score - left.score || left.sourceOrder - right.sourceOrder,
@@ -284,17 +579,20 @@ function dayRelevanceBonus(text, hint) {
   return bonus;
 }
 
-function pickDayFact(title, hint, items, articleText) {
+function pickDayFact(title, hint, items, articleText, topicContext = "") {
   if (!hint) return null;
   const pools = [items];
   if (articleText) pools.push(splitNarrationSentences(articleText));
   for (const pool of pools) {
-    const candidates = scoredCandidates(title, pool)
+    const candidates = scoredCandidates(title, pool, topicContext)
       .map((candidate) => ({
         ...candidate,
         day: dayRelevanceBonus(candidate.text, hint),
       }))
-      .filter((candidate) => candidate.score > -100 && candidate.day >= 7)
+      .filter(
+        (candidate) =>
+          candidate.score > -100 && candidate.day >= 7 && candidate.topic.connected,
+      )
       .sort(
         (left, right) =>
           right.score + right.day - (left.score + left.day) ||
@@ -314,7 +612,7 @@ export function selectInterestingNarrationFacts(
   title,
   items,
   articleText = null,
-  { limit = 3, dateHint = "" } = {},
+  { limit = 3, dateHint = "", topicContext = "" } = {},
 ) {
   const selected = [];
 
@@ -333,13 +631,23 @@ export function selectInterestingNarrationFacts(
     }
   };
 
-  const dayFact = pickDayFact(title, parseDateHint(dateHint), items, articleText);
+  const dayFact = pickDayFact(
+    title,
+    parseDateHint(dateHint),
+    items,
+    articleText,
+    topicContext,
+  );
   if (dayFact) selected.push(dayFact);
 
-  addRankedCandidates(rankedCandidates(title, items));
+  addRankedCandidates(rankedCandidates(title, items, topicContext));
   if (selected.length < limit && articleText) {
     addRankedCandidates(
-      rankedCandidates(title, splitNarrationSentences(articleText)),
+      rankedCandidates(
+        title,
+        splitNarrationSentences(articleText),
+        topicContext,
+      ),
     );
   }
 

--- a/youtube-upload/lib/tracker.js
+++ b/youtube-upload/lib/tracker.js
@@ -22,10 +22,33 @@ export async function getUploaded() {
   return raw ? JSON.parse(raw) : {};
 }
 
-export async function markUploaded(slug, youtubeId, privacy = "public") {
+export async function markUploaded(
+  slug,
+  youtubeId,
+  privacy = "public",
+  metadata = {},
+) {
   const tracker = await getUploaded();
-  tracker[slug] = { youtubeId, uploadedAt: new Date().toISOString(), privacy };
+  tracker[slug] = {
+    youtubeId,
+    uploadedAt: new Date().toISOString(),
+    privacy,
+    ...(metadata?.replacesYoutubeId && metadata.replacesYoutubeId !== youtubeId
+      ? { replacesYoutubeId: metadata.replacesYoutubeId }
+      : {}),
+    ...(metadata?.topicAudit ? { topicAudit: metadata.topicAudit } : {}),
+  };
   await kvPut(TRACKER_KEY, JSON.stringify(tracker));
+}
+
+export async function updateUploaded(slug, updates = {}) {
+  const tracker = await getUploaded();
+  if (!tracker[slug]) {
+    throw new Error(`No YouTube upload is tracked for ${slug}`);
+  }
+  tracker[slug] = { ...tracker[slug], ...updates };
+  await kvPut(TRACKER_KEY, JSON.stringify(tracker));
+  return tracker[slug];
 }
 
 /**

--- a/youtube-upload/lib/youtube.js
+++ b/youtube-upload/lib/youtube.js
@@ -206,6 +206,7 @@ function withTimeout(promise, timeoutMs, message) {
  * @param {string} videoPath  - Path to the MP4 file
  * @param {{ slug: string, title: string, eventTitle?: string, description: string, publishedAt: string }} post
  * @param {number[]} [cuts]   - Scene boundary timestamps for chapter markers
+ * @param {{ privacyStatus?: "private" | "unlisted" | "public" }} [options]
  * @returns {Promise<string>} YouTube video ID
  */
 // Retry only transient network/server failures — never 4xx (quota, auth, or an
@@ -218,7 +219,12 @@ function isRetryableUploadError(err) {
   );
 }
 
-export async function uploadToYoutube(videoPath, post, cuts = []) {
+export async function uploadToYoutube(
+  videoPath,
+  post,
+  cuts = [],
+  { privacyStatus = process.env.YOUTUBE_PRIVACY || "public" } = {},
+) {
   const youtube = getYoutubeClient();
   const requestBody = {
     snippet: {
@@ -230,7 +236,7 @@ export async function uploadToYoutube(videoPath, post, cuts = []) {
       defaultAudioLanguage: "en",
     },
     status: {
-      privacyStatus: process.env.YOUTUBE_PRIVACY || "public",
+      privacyStatus,
       selfDeclaredMadeForKids: false,
     },
   };
@@ -282,4 +288,81 @@ export async function uploadToYoutube(videoPath, post, cuts = []) {
 export async function verifyYoutubeAuth() {
   const auth = getOAuth2Client();
   await auth.getAccessToken();
+}
+
+export async function getYoutubeVideo(videoId) {
+  if (!videoId) throw new Error("Missing YouTube video ID");
+  const youtube = getYoutubeClient();
+  const response = await youtube.videos.list({
+    part: ["snippet", "status"],
+    id: [videoId],
+  });
+  return response.data.items?.[0] || null;
+}
+
+/**
+ * Checks that a staged YouTube upload has the exact article metadata and the
+ * expected non-public/public state. This is pure so the same contract is used
+ * during upload, reviewed promotion, and unit tests.
+ */
+export function auditYoutubeVideo(post, video, { expectedPrivacy } = {}) {
+  const reasons = [];
+  const expectedTitle = buildVideoTitle(post);
+  const expectedArticleUrl = `https://thisday.info/blog/${post.slug}/`;
+  if (!video?.id) reasons.push("video is missing");
+  if (video?.snippet?.title !== expectedTitle) {
+    reasons.push("YouTube title does not match the article topic");
+  }
+  if (!String(video?.snippet?.description || "").includes(expectedArticleUrl)) {
+    reasons.push("YouTube description does not link to the source article");
+  }
+  if (
+    expectedPrivacy &&
+    video?.status?.privacyStatus !== expectedPrivacy
+  ) {
+    reasons.push(
+      `expected privacy ${expectedPrivacy}, found ${video?.status?.privacyStatus || "unknown"}`,
+    );
+  }
+  return {
+    ok: reasons.length === 0,
+    reasons,
+    expectedTitle,
+    actualTitle: video?.snippet?.title || "",
+    expectedPrivacy: expectedPrivacy || null,
+    actualPrivacy: video?.status?.privacyStatus || null,
+  };
+}
+
+export async function setYoutubeVideoPrivacy(videoId, privacyStatus) {
+  if (!videoId) throw new Error("Missing YouTube video ID");
+  if (!["private", "unlisted", "public"].includes(privacyStatus)) {
+    throw new Error(`Unsupported YouTube privacy status: ${privacyStatus}`);
+  }
+  const current = await getYoutubeVideo(videoId);
+  if (!current) throw new Error(`YouTube video ${videoId} was not found`);
+  const currentStatus = current.status || {};
+  const youtube = getYoutubeClient();
+  const response = await youtube.videos.update({
+    part: ["status"],
+    requestBody: {
+      id: videoId,
+      status: {
+        privacyStatus,
+        selfDeclaredMadeForKids:
+          currentStatus.selfDeclaredMadeForKids === true,
+        ...(typeof currentStatus.embeddable === "boolean"
+          ? { embeddable: currentStatus.embeddable }
+          : {}),
+        ...(typeof currentStatus.publicStatsViewable === "boolean"
+          ? { publicStatsViewable: currentStatus.publicStatsViewable }
+          : {}),
+        ...(currentStatus.license ? { license: currentStatus.license } : {}),
+        ...(typeof currentStatus.containsSyntheticMedia === "boolean"
+          ? { containsSyntheticMedia: currentStatus.containsSyntheticMedia }
+          : {}),
+      },
+    },
+  });
+  return response.data;
 }

--- a/youtube-upload/promote-reviewed.js
+++ b/youtube-upload/promote-reviewed.js
@@ -1,0 +1,168 @@
+import "dotenv/config";
+
+import { getPostIndex, getQuickFacts } from "./lib/kv.js";
+import {
+  auditNarrationTopicConnection,
+  buildNarrationTopicContext,
+} from "./lib/narration-selection.js";
+import { videoMatchTitle } from "./lib/titles.js";
+import { getUploaded, updateUploaded } from "./lib/tracker.js";
+import {
+  auditYoutubeVideo,
+  getYoutubeVideo,
+  setYoutubeVideoPrivacy,
+  verifyYoutubeAuth,
+} from "./lib/youtube.js";
+
+async function main() {
+  const slug = String(process.env.PROMOTE_SLUG || "").trim();
+  if (!slug) throw new Error("PROMOTE_SLUG is required");
+  if (process.env.PROMOTE_CONFIRM_TOPIC_REVIEW !== "true") {
+    throw new Error(
+      "PROMOTE_CONFIRM_TOPIC_REVIEW=true is required before public promotion",
+    );
+  }
+
+  const [posts, uploaded, quickFacts] = await Promise.all([
+    getPostIndex(),
+    getUploaded(),
+    getQuickFacts(slug),
+  ]);
+  const post = posts.find((entry) => entry.slug === slug);
+  const tracked = uploaded[slug];
+  if (!post) throw new Error(`Post ${slug} is not present in the blog index`);
+  if (!tracked?.youtubeId) {
+    throw new Error(`No review upload is tracked for ${slug}`);
+  }
+  if (tracked.privacy === "public") {
+    throw new Error(
+      `${slug} is already tracked as public; refusing blind promotion`,
+    );
+  }
+
+  const storedAudit = tracked.topicAudit;
+  if (
+    storedAudit?.version !== 1 ||
+    storedAudit?.connected !== true ||
+    !Array.isArray(storedAudit?.facts) ||
+    !storedAudit.facts.length ||
+    !storedAudit.script ||
+    Number(storedAudit.captionCoverage) < 0.9
+  ) {
+    throw new Error(`The review upload for ${slug} has no complete topic audit`);
+  }
+
+  const title = videoMatchTitle(post);
+  const topicContext = buildNarrationTopicContext(post, quickFacts);
+  const freshAudit = auditNarrationTopicConnection(
+    title,
+    storedAudit.facts,
+    topicContext,
+  );
+  const rebuiltScript = storedAudit.facts
+    .map((fact) => String(fact || "").trim())
+    .filter(Boolean)
+    .join(" ");
+  if (!freshAudit.ok) {
+    const failures = freshAudit.results
+      .filter((result) => !result.connected)
+      .map((result) => `${result.reason}: ${result.text}`)
+      .join(" | ");
+    throw new Error(`TOPIC_REVIEW_FAILED: ${failures}`);
+  }
+  if (rebuiltScript !== storedAudit.script) {
+    throw new Error(
+      "TOPIC_REVIEW_FAILED: stored narration does not match the audited facts",
+    );
+  }
+
+  await verifyYoutubeAuth();
+  const reviewVideo = await getYoutubeVideo(tracked.youtubeId);
+  const reviewVideoAudit = auditYoutubeVideo(post, reviewVideo, {
+    expectedPrivacy: "private",
+  });
+  if (!reviewVideoAudit.ok) {
+    throw new Error(
+      `YOUTUBE_REVIEW_MISMATCH: ${reviewVideoAudit.reasons.join("; ")}`,
+    );
+  }
+
+  console.log(`Topic review passed for ${slug}:`);
+  storedAudit.facts.forEach((fact, index) =>
+    console.log(`  ${index + 1}. ${fact}`),
+  );
+
+  // A same-state update proves the OAuth token can change privacy before the
+  // currently public video is touched.
+  await setYoutubeVideoPrivacy(tracked.youtubeId, "private");
+  const immediateTopicAudit = auditNarrationTopicConnection(
+    title,
+    storedAudit.facts,
+    topicContext,
+  );
+  const immediateVideoAudit = auditYoutubeVideo(
+    post,
+    await getYoutubeVideo(tracked.youtubeId),
+    { expectedPrivacy: "private" },
+  );
+  if (!immediateTopicAudit.ok || !immediateVideoAudit.ok) {
+    throw new Error(
+      "FINAL_TOPIC_RECHECK_FAILED: review upload remains private",
+    );
+  }
+
+  let replacedWasPublic = false;
+  const replacedId =
+    tracked.replacesYoutubeId && tracked.replacesYoutubeId !== tracked.youtubeId
+      ? tracked.replacesYoutubeId
+      : "";
+  if (replacedId) {
+    const replaced = await getYoutubeVideo(replacedId);
+    replacedWasPublic = replaced?.status?.privacyStatus === "public";
+    if (replaced && replaced.status?.privacyStatus !== "private") {
+      await setYoutubeVideoPrivacy(replacedId, "private");
+      const hidden = await getYoutubeVideo(replacedId);
+      if (hidden?.status?.privacyStatus !== "private") {
+        throw new Error(`Previous video ${replacedId} could not be made private`);
+      }
+      console.log(`Previous video ${replacedId} is now private.`);
+    }
+  }
+
+  try {
+    await setYoutubeVideoPrivacy(tracked.youtubeId, "public");
+    const promoted = await getYoutubeVideo(tracked.youtubeId);
+    const promotedAudit = auditYoutubeVideo(post, promoted, {
+      expectedPrivacy: "public",
+    });
+    if (!promotedAudit.ok) {
+      throw new Error(
+        `YouTube promotion audit failed: ${promotedAudit.reasons.join("; ")}`,
+      );
+    }
+    await updateUploaded(slug, {
+      privacy: "public",
+      reviewedAt: new Date().toISOString(),
+      topicAudit: {
+        ...storedAudit,
+        recheckedAt: new Date().toISOString(),
+        connected: true,
+      },
+    });
+  } catch (error) {
+    await setYoutubeVideoPrivacy(tracked.youtubeId, "private").catch(() => {});
+    if (replacedWasPublic && replacedId) {
+      await setYoutubeVideoPrivacy(replacedId, "public").catch(() => {});
+    }
+    throw error;
+  }
+
+  console.log(
+    `Promoted reviewed video: https://www.youtube.com/shorts/${tracked.youtubeId}`,
+  );
+}
+
+main().catch((error) => {
+  console.error(error.stack || error.message);
+  process.exit(1);
+});

--- a/youtube-upload/test-video-text.js
+++ b/youtube-upload/test-video-text.js
@@ -1,10 +1,14 @@
 import assert from "node:assert/strict";
 
 import {
+  extractArticleTextFromHtml,
   extractDidYouKnowFromHtml,
   extractQuickFactsFromHtml,
 } from "./lib/kv.js";
 import {
+  assessNarrationCaptionIntegrity,
+  auditNarrationTopicConnection,
+  buildNarrationTopicContext,
   isInterestingNarrationFact,
   selectInterestingNarrationFacts,
 } from "./lib/narration-selection.js";
@@ -12,6 +16,8 @@ import {
   buildNarrationParts,
   buildNarrationScript,
 } from "./lib/elevenlabs.js";
+import { buildVideoTitle } from "./lib/titles.js";
+import { auditYoutubeVideo } from "./lib/youtube.js";
 
 const TITLE =
   "John F. Kennedy Jr. Dies in Plane Crash — July 16, 1999";
@@ -131,10 +137,172 @@ function testArticleTextOnlyFillsMissingStrongFacts() {
   ]);
 }
 
+function testElPasoCityProfileCannotBecomeNarration() {
+  const post = {
+    title: "How Did the 2019 El Paso Walmart Shooting Unfold?",
+    factualTitle: "El Paso Walmart shooting occurs — August 3, 2019",
+    eventTitle: "El Paso Walmart shooting occurs",
+    sourcePageTitle: "2019 El Paso Walmart shooting",
+    description:
+      "Patrick Crusius drove to El Paso before the attack at the Walmart near Cielo Vista Mall.",
+    keywords:
+      "El Paso, Walmart shooting, domestic terrorism, white nationalism, 8chan, 2019",
+    keyTerms: [{ term: "Patrick Crusius", type: "person" }],
+  };
+  const didYouKnow = [
+    "Video ‘We changed lives’: TLC Foundation shuts down after decades of helping terminal and sick children Video 14 WestJet flights cancelled at London International Airport Video Investigation continues into a boating crash.",
+    "El Paso is a city in and the county seat of El Paso County, Texas. It is the 23rd-most populous city in the U.S. with a population of 678,815 at the 2020 census.",
+    "Crusius surrendered and was arrested and charged with capital murder in connection with the shooting. He posted a manifesto with white nationalist and anti-immigrant themes on 8chan shortly before the attack.",
+    "The El Paso metropolitan area has an estimated 879,000 residents. El Paso stands on the Rio Grande across the Mexico–United States border from Ciudad Juárez.",
+  ];
+  const quickFacts = [
+    "Event: El Paso Walmart shooting occurs",
+    "Date: August 3, 2019",
+    "Location: El Paso, Texas, United States",
+    "Key Figure: Patrick Crusius, a 21-year-old gunman",
+    "Investigation: The Federal Bureau of Investigation investigated the shooting as an act of domestic terrorism and a hate crime.",
+    "Source Subject: 2019 El Paso Walmart shooting",
+  ];
+  const topicContext = buildNarrationTopicContext(post, quickFacts);
+  const selected = selectInterestingNarrationFacts(
+    post.eventTitle,
+    [...didYouKnow, ...quickFacts],
+    null,
+    {
+      limit: 3,
+      dateHint: post.factualTitle,
+      topicContext,
+    },
+  );
+  const audit = auditNarrationTopicConnection(
+    post.eventTitle,
+    selected,
+    topicContext,
+  );
+
+  assert.equal(selected.length, 3);
+  assert.equal(audit.ok, true);
+  assert.ok(
+    selected.every((fact) =>
+      /shooting|attack|gunman|Crusius|terrorism|hate crime|manifesto/i.test(fact),
+    ),
+  );
+  assert.ok(
+    selected.every(
+      (fact) =>
+        !/population|populous|census|residents|Rio Grande|Ciudad Juárez|WestJet|TLC Foundation/i.test(
+          fact,
+        ),
+    ),
+  );
+}
+
+function testArticleFallbackUsesBodyOnly() {
+  const html = `
+    <p class="article-meta">Published August 3, 2026 by thisDay Editorial Team.</p>
+    <p class="dyn-fact">El Paso has a population of 678,815 residents.</p>
+    <!-- Overview -->
+    <section><p>Patrick Crusius opened fire at the El Paso Walmart, killing shoppers and beginning the documented law-enforcement response to the shooting.</p></section>
+    <section><p>The Federal Bureau of Investigation investigated the attack as domestic terrorism and a hate crime while prosecutors pursued federal and state charges.</p></section>
+    <!-- Personal Analysis -->
+    <p>Unrelated recommendation copy after the article body.</p>`;
+  const articleText = extractArticleTextFromHtml(html);
+  assert.match(articleText, /Patrick Crusius opened fire/);
+  assert.match(articleText, /Federal Bureau of Investigation/);
+  assert.doesNotMatch(articleText, /population of 678,815|recommendation copy/);
+}
+
+function testCaptionIntegrityMustMatchApprovedScript() {
+  const script =
+    "Patrick Crusius surrendered after the El Paso Walmart shooting.";
+  const matchingWords = script
+    .split(/\s+/)
+    .map((word, index) => ({ word, start: index, end: index + 0.5 }));
+  assert.equal(assessNarrationCaptionIntegrity(script, matchingWords).ok, true);
+  assert.equal(
+    assessNarrationCaptionIntegrity(script, [
+      { word: "El", start: 0, end: 0.2 },
+      { word: "Paso", start: 0.2, end: 0.4 },
+      { word: "population", start: 0.4, end: 0.8 },
+    ]).ok,
+    false,
+  );
+}
+
+function testTopicAuditNeedsTwoConnectedFacts() {
+  const context = {
+    text: "Apollo 11 moon landing Neil Armstrong Buzz Aldrin",
+    coreText: "Apollo 11 moon landing",
+    personTerms: ["Neil Armstrong", "Buzz Aldrin"],
+    locationText: "Moon",
+  };
+  assert.equal(
+    auditNarrationTopicConnection(
+      "Apollo 11 moon landing",
+      [
+        "Apollo 11 landed on the Moon with Neil Armstrong in command.",
+        "Buzz Aldrin landed with Armstrong and joined him on the lunar surface.",
+      ],
+      context,
+    ).ok,
+    true,
+  );
+  assert.equal(
+    auditNarrationTopicConnection(
+      "Apollo 11 moon landing",
+      ["Apollo 11 landed on the Moon with Neil Armstrong in command."],
+      context,
+    ).ok,
+    false,
+  );
+}
+
+function testYoutubeReviewMetadataMustMatchArticle() {
+  const post = {
+    slug: "3-august-2026",
+    title: "How Did the 2019 El Paso Walmart Shooting Unfold?",
+    eventTitle: "El Paso Walmart shooting occurs",
+    description: "The documented events and aftermath of the Walmart shooting.",
+    publishedAt: "2026-08-03T00:00:00.000Z",
+  };
+  const video = {
+    id: "review-video",
+    snippet: {
+      title: buildVideoTitle(post),
+      description:
+        "Private review\nhttps://thisday.info/blog/3-august-2026/",
+    },
+    status: { privacyStatus: "private" },
+  };
+  assert.equal(
+    auditYoutubeVideo(post, video, { expectedPrivacy: "private" }).ok,
+    true,
+  );
+  assert.equal(
+    auditYoutubeVideo(post, {
+      ...video,
+      snippet: { ...video.snippet, title: "A video about El Paso city" },
+    }, { expectedPrivacy: "private" }).ok,
+    false,
+  );
+  assert.equal(
+    auditYoutubeVideo(post, {
+      ...video,
+      status: { privacyStatus: "public" },
+    }, { expectedPrivacy: "private" }).ok,
+    false,
+  );
+}
+
 testCurrentMarkupExtraction();
 testInterestingFactSelection();
 testNarrationContainsFactsOnly();
 testAllFillerFailsClosed();
 testArticleTextOnlyFillsMissingStrongFacts();
+testElPasoCityProfileCannotBecomeNarration();
+testArticleFallbackUsesBodyOnly();
+testCaptionIntegrityMustMatchApprovedScript();
+testTopicAuditNeedsTwoConnectedFacts();
+testYoutubeReviewMetadataMustMatchArticle();
 
 console.log("Video text tests passed.");


### PR DESCRIPTION
## What changed

- reject navigation, city-profile, and other narration that is not tied to the canonical event
- audit the exact post-trim TTS script and ElevenLabs caption words before rendering/upload
- stage public uploads privately, verify YouTube metadata/privacy, and recheck topic safety before promotion
- keep replacement uploads private until a separate reviewed-promotion workflow rechecks the stored script and swaps the old video safely
- scope article fallback text to the substantive body
- start optional article enrichment one minute after core publication, retaining bounded retries

## Validation

- 549 focused blog/reliability tests passed
- YouTube video-text, narration-selection, and title tests passed
- full YouTube unit suite passed
- all 30 most recent article topics pass the new replay audit; August 3 selects three event-specific facts
- JavaScript syntax, workflow YAML, and diff checks passed
- Blog Worker dry-run bundled at 1042.96 KiB / 261.03 KiB gzip
- production checks were GET-only; no video or KV content was mutated