### PR TITLE
Make single-image Shorts motion more active

### DIFF
--- a/youtube-upload/lib/auth-setup.js
+++ b/youtube-upload/lib/auth-setup.js
@@ -7,13 +7,15 @@
  * 1. A browser tab opens automatically with Google's consent screen.
  * 2. Authorise the app for your YouTube channel.
  * 3. Google redirects to localhost — the script captures the code automatically.
- * 4. Your YOUTUBE_REFRESH_TOKEN is printed — add it to .env (and GitHub Secrets).
+ * 4. Your YOUTUBE_REFRESH_TOKEN is printed, or written to
+ *    YOUTUBE_AUTH_TOKEN_FILE when that safer automation option is supplied.
  */
 
 import { google } from 'googleapis';
 import { createServer } from 'http';
 import { URL } from 'url';
 import { exec } from 'child_process';
+import { writeFileSync } from 'fs';
 import 'dotenv/config';
 
 const PORT = 3838;
@@ -27,7 +29,10 @@ const client = new google.auth.OAuth2(
 
 const authUrl = client.generateAuthUrl({
   access_type: 'offline',
-  scope: ['https://www.googleapis.com/auth/youtube.upload'],
+  scope: [
+    'https://www.googleapis.com/auth/youtube.upload',
+    'https://www.googleapis.com/auth/youtube.force-ssl',
+  ],
   prompt: 'consent',
 });
 
@@ -39,7 +44,7 @@ const opener = process.platform === 'win32'
     : `xdg-open "${authUrl}"`;
 
 console.log('\nOpening browser for Google authorisation...');
-exec(opener);
+if (process.env.YOUTUBE_AUTH_NO_OPEN !== 'true') exec(opener);
 console.log('If the browser did not open, visit this URL manually:\n');
 console.log(authUrl + '\n');
 
@@ -73,6 +78,12 @@ const token = await new Promise((resolve, reject) => {
   });
 });
 
-console.log('\n✓ Success! Add this to your .env file and GitHub Secrets:\n');
-console.log('YOUTUBE_REFRESH_TOKEN=' + token.refresh_token);
-console.log();
+const tokenOutputPath = process.env.YOUTUBE_AUTH_TOKEN_FILE;
+if (tokenOutputPath) {
+  writeFileSync(tokenOutputPath, `${token.refresh_token}\n`, { mode: 0o600 });
+  console.log(`\n✓ Success! Refresh token saved securely to ${tokenOutputPath}.\n`);
+} else {
+  console.log('\n✓ Success! Add this to your .env file and GitHub Secrets:\n');
+  console.log('YOUTUBE_REFRESH_TOKEN=' + token.refresh_token);
+  console.log();
+}

--- a/youtube-upload/lib/video.js
+++ b/youtube-upload/lib/video.js
@@ -55,6 +55,32 @@ const N_SCENES = 1;
 const XFADE_TRANSITIONS = ["fade"];
 
 /**
+ * Motion for a single still: a visible but restrained 7-second breathing
+ * zoom with a small diagonal drift. The former one-pulse-over-the-whole-video
+ * movement was almost imperceptible on 20–45 second Shorts.
+ */
+export function buildSingleImageMotion(durationS) {
+  const d = Math.max(1, Math.round(durationS * FPS));
+  const cycleFrames = Math.max(2, Math.round(7 * FPS));
+  const halfCycle = Math.floor(cycleFrames / 2);
+  const phase = `mod(on,${cycleFrames})`;
+  const zMin = 1.02;
+  const zMax = 1.16;
+  const zRange = 0.14;
+  const zoom =
+    `if(lte(${phase},${halfCycle}),` +
+    `${zMin}+${zRange}*(${phase}/${halfCycle}),` +
+    `${zMax}-${zRange}*((${phase}-${halfCycle})/${cycleFrames - halfCycle}))`;
+  const x =
+    `iw/2-(iw/zoom/2)+(iw-iw/zoom)*0.18*` +
+    `sin(2*PI*on/${cycleFrames})`;
+  const y =
+    `ih/2-(ih/zoom/2)+(ih-ih/zoom)*0.12*` +
+    `cos(2*PI*on/${cycleFrames})`;
+  return { d, cycleFrames, zoom, x, y };
+}
+
+/**
  * Builds an FFmpeg zoompan filter string for a static-image scene (Ken Burns).
  * 6 distinct motion patterns cycled per scene index for maximum visual variety.
  * Input images are pre-scaled to 115% so zoom never reveals black edges.
@@ -78,12 +104,13 @@ function buildKenBurns(sceneIdx, durationS, inLabel, outLabel) {
   let zoom, x, y;
 
   switch (sceneIdx % 6) {
-    case 0: // zoom-in, anchor centre
-      // pzoom accumulates smoothly; clamp at Z_END to avoid overshoot
-      zoom = `if(eq(on,0),${Z_START},min(${Z_END},pzoom+${INC}))`;
-      x = `iw/2-(iw/zoom/2)`;
-      y = `ih/2-(ih/zoom/2)`;
+    case 0: { // repeated zoom pulse + restrained diagonal drift
+      const motion = buildSingleImageMotion(durationS);
+      zoom = motion.zoom;
+      x = motion.x;
+      y = motion.y;
       break;
+    }
     case 1: // zoom-out, anchor centre
       zoom = `if(eq(on,0),${Z_END},max(${Z_START},pzoom-${INC}))`;
       x = `iw/2-(iw/zoom/2)`;
@@ -1692,24 +1719,15 @@ async function generateMultiSceneVideo(
       const endScreenIdx = captionStartIdx + captionPNGPaths.length;
       cmd.input(endScreenPath);
 
-      // Per-scene filter: pulsing zoom — image breathes in then out over full scene.
-      // Z_MIN=1.0 → Z_MAX=1.18 → Z_MIN creates a gentle heartbeat feel.
+      // Per-scene filter: a visible 7-second breathing zoom with restrained
+      // diagonal drift. The branded header and captions remain static.
       // Image occupies W × IMG_H below the header; pad adds HEADER_H+1 px black at top.
       const HEADER_H = 480;
       const IMG_H = H - HEADER_H - 1;
-      const Z_MIN = 1.0;
-      const Z_MAX = 1.18;
-      const Z_RANGE_STR = (Z_MAX - Z_MIN).toFixed(4);
       const sceneParts = bgFiles.map((_, i) => {
-        const d    = Math.round(sceneDurations[i] * FPS);
-        const half = Math.floor(d / 2);
-        // First half: zoom in Z_MIN → Z_MAX; second half: zoom out Z_MAX → Z_MIN
-        const zoom =
-          `if(lte(on,${half}),` +
-            `${Z_MIN.toFixed(4)}+${Z_RANGE_STR}*(on/${half}),` +
-            `${Z_MAX.toFixed(4)}-${Z_RANGE_STR}*((on-${half})/${d - half}))`;
-        const x = `iw/2-(iw/zoom/2)`;
-        const y = `ih/2-(ih/zoom/2)`;
+        const { d, zoom, x, y } = buildSingleImageMotion(
+          sceneDurations[i],
+        );
         // Cinematic grade: slight warmth (lift reds, drop blues) + desaturation + film grain
         const grade = `eq=saturation=0.82:contrast=1.06:gamma_r=1.04:gamma_b=0.94,noise=alls=9:allf=t`;
         // Zoompan outputs W×IMG_H; pad pushes it down below the header panel

--- a/youtube-upload/preview.js
+++ b/youtube-upload/preview.js
@@ -9,8 +9,13 @@ import "dotenv/config";
 import { getPostIndex, getDidYouKnow, getQuickFacts, getArticleText, getPostWikipediaUrl } from "./lib/kv.js";
 import { generateVideo } from "./lib/video.js";
 import { videoHeadlineTitle, videoMatchTitle } from "./lib/titles.js";
-import { generateNarration, buildNarrationScript, buildNarrationParts } from "./lib/elevenlabs.js";
-import { selectInterestingNarrationFacts } from "./lib/narration-selection.js";
+import { generateNarration, buildNarrationParts } from "./lib/elevenlabs.js";
+import {
+  assessNarrationCaptionIntegrity,
+  auditNarrationTopicConnection,
+  buildNarrationTopicContext,
+  selectInterestingNarrationFacts,
+} from "./lib/narration-selection.js";
 import { getMusicPath } from "./lib/music.js";
 
 function getTodaySlug() {
@@ -41,19 +46,35 @@ async function main() {
     getPostWikipediaUrl(slug),
   ]);
   const rawItems = [...(dyk || []), ...(qf || [])];
+  const topicContext = buildNarrationTopicContext(post, qf);
   const selectedItems = selectInterestingNarrationFacts(
     videoMatchTitle(post),
     rawItems,
     articleText,
-    { limit: 3, dateHint: videoHeadlineTitle(post) },
+    { limit: 3, dateHint: videoHeadlineTitle(post), topicContext },
   );
   const contentItems = selectedItems;
   const narrationItems = selectedItems;
+  const narrationParts = buildNarrationParts(post, narrationItems);
+  const topicAudit = auditNarrationTopicConnection(
+    videoMatchTitle(post),
+    narrationParts,
+    topicContext,
+  );
+  if (!topicAudit.ok) {
+    throw new Error(
+      "NARRATION_TOPIC_MISMATCH: preview refused unrelated narration facts",
+    );
+  }
 
-  const script = buildNarrationScript(post, narrationItems);
+  const script = narrationParts.join(" ");
   console.log(`Narration script: "${script}"`);
 
   const { path: narrationPath, words } = await generateNarration(slug, script);
+  const captionAudit = assessNarrationCaptionIntegrity(script, words);
+  if (!captionAudit.ok) {
+    throw new Error(`NARRATION_CAPTION_MISMATCH: ${captionAudit.reason}`);
+  }
   const bgMusicPath = getMusicPath();
   const useAiImage = process.env.USE_AI_IMAGE !== "false";
 
@@ -64,7 +85,7 @@ async function main() {
     useAiImage,
     contentItems: selectedItems,
     wikiArticleUrl: wikiUrl,
-    narrationParts: buildNarrationParts(post, narrationItems),
+    narrationParts,
   });
 
   console.log(`\n✓ Preview video ready: ${videoResult.path}`);

--- a/youtube-upload/test-video-text.js
+++ b/youtube-upload/test-video-text.js
@@ -18,6 +18,7 @@ import {
 } from "./lib/elevenlabs.js";
 import { buildVideoTitle } from "./lib/titles.js";
 import { auditYoutubeVideo } from "./lib/youtube.js";
+import { buildSingleImageMotion } from "./lib/video.js";
 
 const TITLE =
   "John F. Kennedy Jr. Dies in Plane Crash — July 16, 1999";
@@ -294,6 +295,16 @@ function testYoutubeReviewMetadataMustMatchArticle() {
   );
 }
 
+function testSingleImageMotionIsVisibleAndRepeated() {
+  const motion = buildSingleImageMotion(20);
+  assert.equal(motion.d, 600);
+  assert.equal(motion.cycleFrames, 210);
+  assert.match(motion.zoom, /mod\(on,210\)/);
+  assert.match(motion.zoom, /1\.02\+0\.14/);
+  assert.match(motion.x, /sin\(2\*PI\*on\/210\)/);
+  assert.match(motion.y, /cos\(2\*PI\*on\/210\)/);
+}
+
 testCurrentMarkupExtraction();
 testInterestingFactSelection();
 testNarrationContainsFactsOnly();
@@ -304,5 +315,6 @@ testArticleFallbackUsesBodyOnly();
 testCaptionIntegrityMustMatchApprovedScript();
 testTopicAuditNeedsTwoConnectedFacts();
 testYoutubeReviewMetadataMustMatchArticle();
+testSingleImageMotionIsVisibleAndRepeated();
 
 console.log("Video text tests passed.");


### PR DESCRIPTION
Follow-up to #234. Makes the finished green/gold one-image documentary template visibly more active with a repeated seven-second zoom pulse and restrained drift, applies the same safety checks to local previews, and updates OAuth setup for reviewed private-to-public promotion. Verified with the video unit suite, a real FFmpeg render, JavaScript checks, and diff checks.