### PR TITLE
Let manual YouTube retries replace stale locks

### DIFF
--- a/.github/workflows/youtube-upload.yml
+++ b/.github/workflows/youtube-upload.yml
@@ -100,6 +100,7 @@ jobs:
           # reuploads private even if the scheduled channel uses another mode.
           YOUTUBE_PRIVACY: ${{ github.event_name == 'workflow_dispatch' && 'private' || secrets.YOUTUBE_PRIVACY }}
           HOLD_FOR_TOPIC_REVIEW: ${{ github.event_name == 'workflow_dispatch' && 'true' || 'false' }}
+          REPLACE_UPLOAD_LOCK: ${{ github.event_name == 'workflow_dispatch' && inputs.mode == 'upload-private' && 'true' || 'false' }}
           ALLOW_SILENT_VIDEO: ${{ secrets.ALLOW_SILENT_VIDEO }}
           REUPLOAD_SLUGS: ${{ github.event_name == 'workflow_dispatch' && inputs.slug || secrets.REUPLOAD_SLUGS }}
           MAX_UPLOADS_PER_RUN: ${{ secrets.MAX_UPLOADS_PER_RUN }}

--- a/youtube-upload/index.js
+++ b/youtube-upload/index.js
@@ -333,7 +333,12 @@ async function main() {
   }
 
   const uploadLockOwner = `${process.env.GITHUB_RUN_ID || "local"}:${process.pid}`;
-  const uploadLockToken = await acquireUploadLock(uploadLockOwner);
+  const uploadLockToken = await acquireUploadLock(uploadLockOwner, {
+    // GitHub's non-overlapping concurrency group proves there is no other
+    // active upload job when a manual replacement starts. This lets a manual
+    // retry replace the orphaned KV lock left by a cancelled runner.
+    replaceExisting: process.env.REPLACE_UPLOAD_LOCK === "true",
+  });
   if (!uploadLockToken) {
     console.warn("Upload already in progress — skipping this run.");
     return;

--- a/youtube-upload/lib/tracker.js
+++ b/youtube-upload/lib/tracker.js
@@ -68,30 +68,41 @@ export async function markSocialPosted(slug, { meta, tiktok, pinterest } = {}) {
   await kvPut(TRACKER_KEY, JSON.stringify(tracker));
 }
 
+/** Returns whether a parsed upload-lock record is still inside its six-hour TTL. */
+export function isUploadLockActive(existing, now = new Date()) {
+  const claimedAt = existing?.claimedAt ? new Date(existing.claimedAt) : null;
+  return Boolean(
+    claimedAt &&
+      Number.isFinite(claimedAt.getTime()) &&
+      now.getTime() - claimedAt.getTime() < LOCK_TTL_MS,
+  );
+}
+
 /**
  * Tries to acquire a distributed upload lock stored in KV.
  * Returns a token string if the lock was acquired, or null if another run holds it.
  * The lock expires automatically after LOCK_TTL_MS (6 h) so stale locks don't block forever.
  * Note: KV has no atomic compare-and-set; the GH Actions concurrency group is the primary
  * guard against simultaneous runs — this lock is a belt-and-suspenders safeguard.
+ * Manual Actions retries may replace an existing lock because the non-overlapping workflow
+ * concurrency group proves that the prior job has ended.
  *
  * @param {string} [owner]  Identifier for the process claiming the lock (e.g. run ID).
+ * @param {{ replaceExisting?: boolean }} [options]
  * @returns {Promise<string|null>}
  */
-export async function acquireUploadLock(owner = "youtube-upload") {
+export async function acquireUploadLock(
+  owner = "youtube-upload",
+  { replaceExisting = false } = {},
+) {
   const now = new Date();
   const existingRaw = await kvGet(UPLOAD_LOCK_KEY);
 
   if (existingRaw) {
     try {
       const existing = JSON.parse(existingRaw);
-      const claimedAt = existing?.claimedAt
-        ? new Date(existing.claimedAt)
-        : null;
-      if (claimedAt && Number.isFinite(claimedAt.getTime())) {
-        if (now.getTime() - claimedAt.getTime() < LOCK_TTL_MS) {
-          return null;
-        }
+      if (!replaceExisting && isUploadLockActive(existing, now)) {
+        return null;
       }
     } catch {
       // Treat malformed lock as stale and overwrite below.

--- a/youtube-upload/test-video-text.js
+++ b/youtube-upload/test-video-text.js
@@ -19,6 +19,7 @@ import {
 import { buildVideoTitle } from "./lib/titles.js";
 import { auditYoutubeVideo } from "./lib/youtube.js";
 import { buildSingleImageMotion } from "./lib/video.js";
+import { isUploadLockActive } from "./lib/tracker.js";
 
 const TITLE =
   "John F. Kennedy Jr. Dies in Plane Crash — July 16, 1999";
@@ -305,6 +306,18 @@ function testSingleImageMotionIsVisibleAndRepeated() {
   assert.match(motion.y, /cos\(2\*PI\*on\/210\)/);
 }
 
+function testCancelledUploadLockCanBeIdentified() {
+  const now = new Date("2026-08-03T18:10:00.000Z");
+  assert.equal(
+    isUploadLockActive({ claimedAt: "2026-08-03T18:09:00.000Z" }, now),
+    true,
+  );
+  assert.equal(
+    isUploadLockActive({ claimedAt: "2026-08-03T11:00:00.000Z" }, now),
+    false,
+  );
+}
+
 testCurrentMarkupExtraction();
 testInterestingFactSelection();
 testNarrationContainsFactsOnly();
@@ -316,5 +329,6 @@ testCaptionIntegrityMustMatchApprovedScript();
 testTopicAuditNeedsTwoConnectedFacts();
 testYoutubeReviewMetadataMustMatchArticle();
 testSingleImageMotionIsVisibleAndRepeated();
+testCancelledUploadLockCanBeIdentified();
 
 console.log("Video text tests passed.");


### PR DESCRIPTION
Allows an explicitly dispatched private retry to replace the orphaned KV upload lock from a cancelled runner. Scheduled runs retain the six-hour lock behavior, and GitHub's non-overlapping concurrency group remains the primary guard. Video text tests, JavaScript checks, workflow YAML parsing, and diff checks pass.