### PR TITLE
Trust live YouTube privacy during review

### DIFF
--- a/youtube-upload/promote-reviewed.js
+++ b/youtube-upload/promote-reviewed.js
@@ -34,9 +34,12 @@ async function main() {
   if (!tracked?.youtubeId) {
     throw new Error(`No review upload is tracked for ${slug}`);
   }
+  console.log(
+    `Review tracker: youtubeId=${tracked.youtubeId}, privacy=${tracked.privacy || "unknown"}`,
+  );
   if (tracked.privacy === "public") {
-    throw new Error(
-      `${slug} is already tracked as public; refusing blind promotion`,
+    console.warn(
+      "Tracker privacy is stale/public; requiring the live YouTube private-state audit before promotion.",
     );
   }
 


### PR DESCRIPTION
Keeps the reviewed-promotion gate fail-closed while treating live YouTube status as authoritative over a stale KV privacy field. A tracker marked public can proceed only when the referenced video's live metadata matches the article and YouTube confirms it is private. JavaScript, video text, and diff checks pass.