### PR TITLE
Preserve YouTube replacement review chain

### DIFF
--- a/.github/workflows/youtube-upload.yml
+++ b/.github/workflows/youtube-upload.yml
@@ -20,6 +20,7 @@ on:
         options:
           - upload-private
           - promote-reviewed
+          - retire-replaced
       slug:
         description: "Blog slug, for example 3-august-2026"
         required: true
@@ -29,6 +30,10 @@ on:
         required: false
         type: boolean
         default: false
+      retire_video_id:
+        description: "For retire-replaced only: an older same-article YouTube ID to make private"
+        required: false
+        type: string
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -127,8 +132,8 @@ jobs:
           META_SKIP_FACEBOOK: ${{ github.event_name == 'workflow_dispatch' && 'true' || '' }}
           TIKTOK_SKIP: ${{ github.event_name == 'workflow_dispatch' && 'true' || '' }}
 
-      - name: Promote reviewed video to public
-        if: github.event_name == 'workflow_dispatch' && inputs.mode == 'promote-reviewed'
+      - name: Promote or reconcile reviewed video
+        if: github.event_name == 'workflow_dispatch' && (inputs.mode == 'promote-reviewed' || inputs.mode == 'retire-replaced')
         run: node promote-reviewed.js
         env:
           CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
@@ -139,3 +144,5 @@ jobs:
           YOUTUBE_REFRESH_TOKEN: ${{ secrets.YOUTUBE_REFRESH_TOKEN }}
           PROMOTE_SLUG: ${{ inputs.slug }}
           PROMOTE_CONFIRM_TOPIC_REVIEW: ${{ inputs.confirm_topic_review }}
+          PROMOTE_RETIRE_ONLY: ${{ inputs.mode == 'retire-replaced' && 'true' || 'false' }}
+          PROMOTE_RETIRE_VIDEO_ID: ${{ inputs.retire_video_id }}

--- a/tools/youtube-upload-workflow.test.js
+++ b/tools/youtube-upload-workflow.test.js
@@ -21,3 +21,14 @@ test("YouTube upload installs and verifies FFmpeg without a release-discovery ac
   assert.match(workflow, /ffmpeg -version/);
   assert.match(workflow, /ffprobe -version/);
 });
+
+test("YouTube workflow can safely reconcile a transitive replacement chain", () => {
+  assert.match(workflow, /- retire-replaced/);
+  assert.match(workflow, /retire_video_id:/);
+  assert.match(
+    workflow,
+    /inputs\.mode == 'promote-reviewed' \|\| inputs\.mode == 'retire-replaced'/,
+  );
+  assert.match(workflow, /PROMOTE_RETIRE_ONLY:/);
+  assert.match(workflow, /PROMOTE_RETIRE_VIDEO_ID:/);
+});

--- a/youtube-upload/index.js
+++ b/youtube-upload/index.js
@@ -60,6 +60,7 @@ import {
 } from "./lib/youtube.js";
 import {
   acquireUploadLock,
+  collectReplacedYoutubeIds,
   getUploaded,
   markUploaded,
   recordQuotaSignal,
@@ -614,6 +615,10 @@ async function main() {
         // Record in KV tracker (overwrites previous entry for re-uploads)
         await markUploaded(post.slug, youtubeId, privacy, {
           replacesYoutubeId: replacedUpload?.youtubeId || "",
+          replacesYoutubeIds: collectReplacedYoutubeIds(
+            replacedUpload,
+            youtubeId,
+          ),
           topicAudit: storedTopicAudit,
         });
         console.log(

--- a/youtube-upload/lib/tracker.js
+++ b/youtube-upload/lib/tracker.js
@@ -22,6 +22,22 @@ export async function getUploaded() {
   return raw ? JSON.parse(raw) : {};
 }
 
+export function collectReplacedYoutubeIds(entry, currentYoutubeId = "") {
+  const values = [
+    entry?.youtubeId,
+    ...(Array.isArray(entry?.replacesYoutubeIds)
+      ? entry.replacesYoutubeIds
+      : []),
+    entry?.replacesYoutubeId,
+    ...(Array.isArray(entry?.retiredYoutubeIds)
+      ? entry.retiredYoutubeIds
+      : []),
+  ];
+  return [...new Set(values.map((value) => String(value || "").trim()))]
+    .filter(Boolean)
+    .filter((value) => value !== currentYoutubeId);
+}
+
 export async function markUploaded(
   slug,
   youtubeId,
@@ -29,12 +45,28 @@ export async function markUploaded(
   metadata = {},
 ) {
   const tracker = await getUploaded();
+  const replacedYoutubeIds = [
+    ...(Array.isArray(metadata?.replacesYoutubeIds)
+      ? metadata.replacesYoutubeIds
+      : []),
+    metadata?.replacesYoutubeId,
+  ];
+  const normalizedReplacements = [
+    ...new Set(
+      replacedYoutubeIds.map((value) => String(value || "").trim()),
+    ),
+  ]
+    .filter(Boolean)
+    .filter((value) => value !== youtubeId);
   tracker[slug] = {
     youtubeId,
     uploadedAt: new Date().toISOString(),
     privacy,
-    ...(metadata?.replacesYoutubeId && metadata.replacesYoutubeId !== youtubeId
-      ? { replacesYoutubeId: metadata.replacesYoutubeId }
+    ...(normalizedReplacements.length > 0
+      ? {
+          replacesYoutubeId: normalizedReplacements[0],
+          replacesYoutubeIds: normalizedReplacements,
+        }
       : {}),
     ...(metadata?.topicAudit ? { topicAudit: metadata.topicAudit } : {}),
   };

--- a/youtube-upload/promote-reviewed.js
+++ b/youtube-upload/promote-reviewed.js
@@ -6,7 +6,11 @@ import {
   buildNarrationTopicContext,
 } from "./lib/narration-selection.js";
 import { videoMatchTitle } from "./lib/titles.js";
-import { getUploaded, updateUploaded } from "./lib/tracker.js";
+import {
+  collectReplacedYoutubeIds,
+  getUploaded,
+  updateUploaded,
+} from "./lib/tracker.js";
 import {
   auditYoutubeVideo,
   getYoutubeVideo,
@@ -14,13 +18,54 @@ import {
   verifyYoutubeAuth,
 } from "./lib/youtube.js";
 
+async function retireReplacedVideos(post, videoIds) {
+  const changedVideos = [];
+  try {
+    for (const videoId of videoIds) {
+      const video = await getYoutubeVideo(videoId);
+      if (!video) {
+        throw new Error(`Previous video ${videoId} was not found`);
+      }
+      const metadataAudit = auditYoutubeVideo(post, video);
+      if (!metadataAudit.ok) {
+        throw new Error(
+          `REFUSING_VIDEO_RETIREMENT: ${videoId}: ${metadataAudit.reasons.join("; ")}`,
+        );
+      }
+      const previousPrivacy = video.status?.privacyStatus;
+      if (previousPrivacy !== "private") {
+        changedVideos.push({ videoId, privacyStatus: previousPrivacy });
+        await setYoutubeVideoPrivacy(videoId, "private");
+      }
+      const hidden = await getYoutubeVideo(videoId);
+      if (hidden?.status?.privacyStatus !== "private") {
+        throw new Error(`Previous video ${videoId} could not be made private`);
+      }
+      console.log(`Previous video ${videoId} is now private.`);
+    }
+    return changedVideos;
+  } catch (error) {
+    for (const { videoId, privacyStatus } of changedVideos) {
+      await setYoutubeVideoPrivacy(videoId, privacyStatus).catch(() => {});
+    }
+    throw error;
+  }
+}
+
 async function main() {
   const slug = String(process.env.PROMOTE_SLUG || "").trim();
+  const retireOnly = process.env.PROMOTE_RETIRE_ONLY === "true";
+  const explicitRetireId = String(
+    process.env.PROMOTE_RETIRE_VIDEO_ID || "",
+  ).trim();
   if (!slug) throw new Error("PROMOTE_SLUG is required");
   if (process.env.PROMOTE_CONFIRM_TOPIC_REVIEW !== "true") {
     throw new Error(
       "PROMOTE_CONFIRM_TOPIC_REVIEW=true is required before public promotion",
     );
+  }
+  if (explicitRetireId && !/^[A-Za-z0-9_-]{11}$/.test(explicitRetireId)) {
+    throw new Error("PROMOTE_RETIRE_VIDEO_ID is not a valid YouTube video ID");
   }
 
   const [posts, uploaded, quickFacts] = await Promise.all([
@@ -37,9 +82,14 @@ async function main() {
   console.log(
     `Review tracker: youtubeId=${tracked.youtubeId}, privacy=${tracked.privacy || "unknown"}`,
   );
-  if (tracked.privacy === "public") {
+  if (tracked.privacy === "public" && !retireOnly) {
     console.warn(
       "Tracker privacy is stale/public; requiring the live YouTube private-state audit before promotion.",
+    );
+  }
+  if (retireOnly && tracked.privacy !== "public") {
+    console.warn(
+      "Tracker privacy is stale/non-public; requiring the live YouTube public-state audit before reconciliation.",
     );
   }
 
@@ -82,7 +132,7 @@ async function main() {
   await verifyYoutubeAuth();
   const reviewVideo = await getYoutubeVideo(tracked.youtubeId);
   const reviewVideoAudit = auditYoutubeVideo(post, reviewVideo, {
-    expectedPrivacy: "private",
+    expectedPrivacy: retireOnly ? "public" : "private",
   });
   if (!reviewVideoAudit.ok) {
     throw new Error(
@@ -95,9 +145,6 @@ async function main() {
     console.log(`  ${index + 1}. ${fact}`),
   );
 
-  // A same-state update proves the OAuth token can change privacy before the
-  // currently public video is touched.
-  await setYoutubeVideoPrivacy(tracked.youtubeId, "private");
   const immediateTopicAudit = auditNarrationTopicConnection(
     title,
     storedAudit.facts,
@@ -106,30 +153,53 @@ async function main() {
   const immediateVideoAudit = auditYoutubeVideo(
     post,
     await getYoutubeVideo(tracked.youtubeId),
-    { expectedPrivacy: "private" },
+    { expectedPrivacy: retireOnly ? "public" : "private" },
   );
   if (!immediateTopicAudit.ok || !immediateVideoAudit.ok) {
     throw new Error(
-      "FINAL_TOPIC_RECHECK_FAILED: review upload remains private",
+      "FINAL_TOPIC_RECHECK_FAILED: current reviewed upload was not changed",
     );
   }
 
-  let replacedWasPublic = false;
-  const replacedId =
-    tracked.replacesYoutubeId && tracked.replacesYoutubeId !== tracked.youtubeId
-      ? tracked.replacesYoutubeId
-      : "";
-  if (replacedId) {
-    const replaced = await getYoutubeVideo(replacedId);
-    replacedWasPublic = replaced?.status?.privacyStatus === "public";
-    if (replaced && replaced.status?.privacyStatus !== "private") {
-      await setYoutubeVideoPrivacy(replacedId, "private");
-      const hidden = await getYoutubeVideo(replacedId);
-      if (hidden?.status?.privacyStatus !== "private") {
-        throw new Error(`Previous video ${replacedId} could not be made private`);
-      }
-      console.log(`Previous video ${replacedId} is now private.`);
-    }
+  if (!retireOnly) {
+    // A same-state update proves the OAuth token can change privacy before any
+    // replaced public video is touched.
+    await setYoutubeVideoPrivacy(tracked.youtubeId, "private");
+  }
+
+  const replacementIds = [
+    ...collectReplacedYoutubeIds(tracked, tracked.youtubeId),
+    explicitRetireId,
+  ];
+  const uniqueReplacementIds = [...new Set(replacementIds)]
+    .filter(Boolean)
+    .filter((videoId) => videoId !== tracked.youtubeId);
+  if (retireOnly && uniqueReplacementIds.length === 0) {
+    throw new Error(
+      "PROMOTE_RETIRE_VIDEO_ID or a tracked replacement is required",
+    );
+  }
+  const replacedPreviousPrivacy = await retireReplacedVideos(
+    post,
+    uniqueReplacementIds,
+  );
+
+  if (retireOnly) {
+    await updateUploaded(slug, {
+      retiredYoutubeIds: [
+        ...new Set([
+          ...(Array.isArray(tracked.retiredYoutubeIds)
+            ? tracked.retiredYoutubeIds
+            : []),
+          ...uniqueReplacementIds,
+        ]),
+      ],
+      replacementsReconciledAt: new Date().toISOString(),
+    });
+    console.log(
+      `Reconciled replaced videos for reviewed public upload ${tracked.youtubeId}.`,
+    );
+    return;
   }
 
   try {
@@ -151,11 +221,12 @@ async function main() {
         recheckedAt: new Date().toISOString(),
         connected: true,
       },
+      retiredYoutubeIds: uniqueReplacementIds,
     });
   } catch (error) {
     await setYoutubeVideoPrivacy(tracked.youtubeId, "private").catch(() => {});
-    if (replacedWasPublic && replacedId) {
-      await setYoutubeVideoPrivacy(replacedId, "public").catch(() => {});
+    for (const { videoId, privacyStatus } of replacedPreviousPrivacy) {
+      await setYoutubeVideoPrivacy(videoId, privacyStatus).catch(() => {});
     }
     throw error;
   }

--- a/youtube-upload/test-video-text.js
+++ b/youtube-upload/test-video-text.js
@@ -19,7 +19,10 @@ import {
 import { buildVideoTitle } from "./lib/titles.js";
 import { auditYoutubeVideo } from "./lib/youtube.js";
 import { buildSingleImageMotion } from "./lib/video.js";
-import { isUploadLockActive } from "./lib/tracker.js";
+import {
+  collectReplacedYoutubeIds,
+  isUploadLockActive,
+} from "./lib/tracker.js";
 
 const TITLE =
   "John F. Kennedy Jr. Dies in Plane Crash — July 16, 1999";
@@ -318,6 +321,21 @@ function testCancelledUploadLockCanBeIdentified() {
   );
 }
 
+function testReplacementChainSurvivesConcurrentRetries() {
+  assert.deepEqual(
+    collectReplacedYoutubeIds(
+      {
+        youtubeId: "l4gt2Z3kpck",
+        replacesYoutubeId: "2ALMrrP9NGQ",
+        replacesYoutubeIds: ["2ALMrrP9NGQ"],
+        retiredYoutubeIds: ["olderVideo1"],
+      },
+      "o5M2vK4Przs",
+    ),
+    ["l4gt2Z3kpck", "2ALMrrP9NGQ", "olderVideo1"],
+  );
+}
+
 testCurrentMarkupExtraction();
 testInterestingFactSelection();
 testNarrationContainsFactsOnly();
@@ -330,5 +348,6 @@ testTopicAuditNeedsTwoConnectedFacts();
 testYoutubeReviewMetadataMustMatchArticle();
 testSingleImageMotionIsVisibleAndRepeated();
 testCancelledUploadLockCanBeIdentified();
+testReplacementChainSurvivesConcurrentRetries();
 
 console.log("Video text tests passed.");


### PR DESCRIPTION
## Summary
- preserve every replaced YouTube ID across concurrent private retries
- recheck the current public video topic, captions, title, article URL, and live privacy before retiring anything
- verify each older video belongs to the same article, make it private, and roll back prior privacy states on failure
- add an audited retire-replaced recovery mode for the existing August 3 chain

## Tests
- npm run test:unit
- node --test tools/youtube-upload-workflow.test.js
- node --check for changed JavaScript
- GitHub workflow YAML parse
- git diff --check

## Production impact
The recovery uses YouTube API reads/updates and one compare-sized KV tracker update. It does not regenerate or republish article content.