### PR TITLE
Allow regional Google Analytics collection

### DIFF
--- a/js/seo-worker.js
+++ b/js/seo-worker.js
@@ -10049,7 +10049,7 @@ async function handleFetchRequest(request, env, ctx) {
   const csp =
     `default-src 'none'; ` +
     `connect-src 'self' https://api.wikimedia.org https://en.wikipedia.org https://cdn.jsdelivr.net ` +
-    `https://www.google-analytics.com https://analytics.google.com https://*.google-analytics.com https://www.google.com https://www.google.ba https://www.gstatic.com ` +
+    `https://www.google-analytics.com https://analytics.google.com https://*.analytics.google.com https://*.google-analytics.com https://www.google.com https://www.google.ba https://www.gstatic.com ` +
     `https://www.googleadservices.com https://pagead2.googlesyndication.com ` +
     `https://*.adtrafficquality.google https://*.doubleclick.net ` +
     `https://www.googletagmanager.com https://fundingchoicesmessages.google.com https://openlibrary.org; ` +

--- a/tools/indexing-guardrails.test.js
+++ b/tools/indexing-guardrails.test.js
@@ -9,6 +9,14 @@ import { __indexabilityTestHooks as hooks } from "../js/seo-worker.js";
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 const serviceWorker = readFileSync(join(root, "sw.js"), "utf8");
 const homepage = readFileSync(join(root, "index.html"), "utf8");
+const seoWorker = readFileSync(join(root, "js/seo-worker.js"), "utf8");
+
+test("homepage CSP permits regional Google Analytics collection", () => {
+  assert.match(
+    seoWorker,
+    /connect-src[\s\S]*?https:\/\/analytics\.google\.com https:\/\/\*\.analytics\.google\.com https:\/\/\*\.google-analytics\.com/,
+  );
+});
 
 test("maintenance content is served as a temporary non-cacheable response", async () => {
   const request = new Request("https://thisday.info/some-public-page/");


### PR DESCRIPTION
## What changed

- Allow `https://*.analytics.google.com` in the homepage `connect-src` Content Security Policy.
- Add a regression test covering the regional Google Analytics collection hostname.

## Root cause

Google Analytics sends page views to `region1.analytics.google.com`. The policy allowed only the apex `analytics.google.com` host and `*.google-analytics.com`, so browsers blocked the collection request.

## Validation

- 171 tracked production tests passed.
- JavaScript syntax and diff checks passed.
- SEO Worker dry-run bundled successfully.

This changes only the SEO response header and performs no KV or content mutation.
