### PR TITLE
Use article overviews and multiple images in videos

### DIFF
--- a/.github/workflows/youtube-upload.yml
+++ b/.github/workflows/youtube-upload.yml
@@ -112,6 +112,7 @@ jobs:
           BLOG_WORKER_URL: ${{ secrets.BLOG_WORKER_URL }}
           YOUTUBE_REGEN_SECRET: ${{ secrets.YOUTUBE_REGEN_SECRET }}
           USE_AI_IMAGE: ${{ secrets.USE_AI_IMAGE }}
+          WIKI_IMAGE_MIN_COUNT: ${{ secrets.WIKI_IMAGE_MIN_COUNT }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_TOKEN_2: ${{ secrets.HF_TOKEN_2 }}
           HF_TOKEN_3: ${{ secrets.HF_TOKEN_3 }}

--- a/youtube-upload/index.js
+++ b/youtube-upload/index.js
@@ -4,10 +4,10 @@
  * Reads new AI blog posts from Cloudflare KV, generates a Shorts-format
  * MP4 for each one, and uploads it to YouTube.
  *
- * Audio:  ElevenLabs TTS narration (from Did You Know / Quick Facts section)
- *         mixed with background music (assets/background.mp3) at 15% volume.
- * Image:  Exact Wikipedia-article mode. Pulls scene images only from the
- *         specific Wikipedia article tied to the post topic.
+ * Audio:  ElevenLabs TTS narration (article Overview first, with Did You Know /
+ *         Quick Facts fallback) mixed with background music at 15% volume.
+ * Image:  Multi-scene mode. Uses the post's featured and inline article
+ *         images first, then the exact Wikipedia article as a fallback.
  * Schedule: Mon/Tue/Thu/Fri via GitHub Actions cron at 13:00 UTC
  *           (about 09:00 Eastern during daylight saving time)
  *
@@ -37,6 +37,7 @@ import {
   getDidYouKnow,
   getQuickFacts,
   getArticleText,
+  getOverviewNarration,
   getPostWikipediaUrl,
   updateIndexEntry,
   deleteIndexEntry,
@@ -44,11 +45,9 @@ import {
 import {
   assessNarrationCaptionIntegrity,
   auditNarrationTopicConnection,
-  buildNarrationTopicContext,
-  selectInterestingNarrationFacts,
 } from "./lib/narration-selection.js";
 import { generateVideo, resolvePostImage } from "./lib/video.js";
-import { videoHeadlineTitle, videoMatchTitle } from "./lib/titles.js";
+import { videoMatchTitle } from "./lib/titles.js";
 import { verifyKvReadWriteAccess } from "./lib/kv.js";
 import { checkVideoQuality } from "./lib/video-quality.js";
 import {
@@ -73,10 +72,8 @@ import { getMusicPath } from "./lib/music.js";
 import { notifyUpload } from "./lib/notify.js";
 import { postToMeta } from "./lib/meta.js";
 import { postToTikTok } from "./lib/tiktok.js";
-import {
-  generateNarration,
-  buildNarrationParts,
-} from "./lib/elevenlabs.js";
+import { generateNarration } from "./lib/elevenlabs.js";
+import { prepareNarrationSource } from "./lib/narration-source.js";
 
 // Parse REUPLOAD_SLUGS from env into a Set.
 // Accepts: "a,b,c" or "a b c" or newline-separated.
@@ -357,88 +354,56 @@ async function main() {
       let videoResult = null;
       try {
         // ── ElevenLabs TTS narration ───────────────────────────────────────────
-        // Source text: current/legacy Did You Know and Quick Facts markup.
-        console.log("  Fetching Did You Know / Quick Facts from KV...");
-        const [dykItems, quickFacts] = await Promise.all([
+        // Current posts prefer the first Overview paragraph. Curated fact cards
+        // remain the deterministic fallback for older or weak articles.
+        console.log("  Fetching Overview and fallback facts from KV...");
+        const [overviewText, dykItems, quickFacts, articleText] = await Promise.all([
+          getOverviewNarration(post.slug),
           getDidYouKnow(post.slug),
           getQuickFacts(post.slug),
+          getArticleText(post.slug).catch(() => null),
         ]);
-        const contentItems = [
-          ...(dykItems || []),
-          ...(quickFacts || []),
-        ];
-
-        if (contentItems.length > 0) {
-          console.log(
-            `  Found ${dykItems?.length || 0} Did You Know and ${quickFacts?.length || 0} Quick Facts item(s).`,
-          );
-        } else {
-          console.log(
-            "  No DYK/Quick Facts found — scanning article text for concrete facts.",
-          );
-        }
-
-        // Deterministically select concrete source-backed facts. Article text is
-        // used only to fill gaps left by the two curated fact sections.
-        const articleText = await getArticleText(post.slug).catch(() => null);
         const wikiArticleUrl = await getPostWikipediaUrl(post.slug).catch(
           () => null,
         );
-        const narrationTopicContext = buildNarrationTopicContext(
-          post,
+        const narration = prepareNarrationSource(post, {
+          overviewText,
+          didYouKnow: dykItems,
           quickFacts,
-        );
-        const selectedNarrationItems = selectInterestingNarrationFacts(
-          videoMatchTitle(post),
-          contentItems,
           articleText,
-          {
-            limit: 3,
-            dateHint: videoHeadlineTitle(post),
-            topicContext: narrationTopicContext,
-          },
-        );
-        if (selectedNarrationItems.length > 0) {
+        });
+        const narrationTopicContext = narration.topicContext;
+        const narrationParts = narration.narrationParts;
+        const narrationContentItems = narration.contentItems;
+
+        if (narration.source === "overview") {
           console.log(
-            `  Selected ${selectedNarrationItems.length} high-interest narration fact(s):`,
+            `  ✓ Using Overview narration verbatim (${narration.overviewAssessment.words} words, ${narration.overviewAssessment.sentences} sentences).`,
           );
-          selectedNarrationItems.forEach((item, index) =>
+        } else {
+          const overviewReasons = narration.overviewAssessment.reasons.join("; ");
+          console.log(
+            `  Overview fallback: ${overviewReasons || "Overview section is unavailable"}.`,
+          );
+          console.log(
+            `  Found ${dykItems?.length || 0} Did You Know and ${quickFacts?.length || 0} Quick Facts item(s).`,
+          );
+        }
+
+        if (narrationContentItems.length > 0) {
+          console.log(
+            `  Prepared ${narrationContentItems.length} ${narration.source === "overview" ? "overview part" : "high-interest fact"}(s):`,
+          );
+          narrationContentItems.forEach((item, index) =>
             console.log(`    ${index + 1}. ${item}`),
           );
         } else {
           console.warn(
-            "  ⚠ No high-interest source facts passed selection — using the headline only.",
-          );
-        }
-
-        const narrationItems = selectedNarrationItems;
-        const preparedNarrationParts = buildNarrationParts(
-          post,
-          narrationItems,
-        );
-        // Date trimming can remove the only topic anchor from an otherwise
-        // eligible candidate. Audit the exact post-trim text that TTS will
-        // receive, drop any disconnected part, and require the remaining
-        // script to pass as a whole.
-        const preparedTopicAudit = auditNarrationTopicConnection(
-          videoMatchTitle(post),
-          preparedNarrationParts,
-          narrationTopicContext,
-        );
-        const narrationParts = preparedTopicAudit.results
-          .filter((result) => result.connected)
-          .map((result) => result.text);
-        if (narrationParts.length !== preparedNarrationParts.length) {
-          console.warn(
-            `  ⚠ Dropped ${preparedNarrationParts.length - narrationParts.length} narration fact(s) after the exact TTS-text topic check.`,
+            "  ⚠ No narration content passed deterministic selection.",
           );
         }
         const script = narrationParts.join(" ");
-        const topicAudit = auditNarrationTopicConnection(
-          videoMatchTitle(post),
-          narrationParts,
-          narrationTopicContext,
-        );
+        const topicAudit = narration.topicAudit;
         if (!topicAudit.ok) {
           const failures = topicAudit.results
             .filter((result) => !result.connected)
@@ -454,6 +419,7 @@ async function main() {
           checkedAt: new Date().toISOString(),
           title: topicAudit.title,
           connected: true,
+          source: narration.source,
           facts: narrationParts,
           script,
         };
@@ -515,7 +481,7 @@ async function main() {
             bgMusicPath,
             words: narrWords,
             useAiImage,
-            contentItems: selectedNarrationItems,
+            contentItems: narrationContentItems,
             wikiArticleUrl,
             narrationParts,
             qualityHint,
@@ -560,6 +526,7 @@ async function main() {
           videoMatchTitle(post),
           narrationParts,
           narrationTopicContext,
+          { continuousNarrative: narration.source === "overview" },
         );
         const finalCaptionAudit = assessNarrationCaptionIntegrity(
           script,
@@ -592,6 +559,7 @@ async function main() {
             videoMatchTitle(post),
             narrationParts,
             narrationTopicContext,
+            { continuousNarrative: narration.source === "overview" },
           );
           const promotionCaptionAudit = assessNarrationCaptionIntegrity(
             script,

--- a/youtube-upload/lib/elevenlabs.js
+++ b/youtube-upload/lib/elevenlabs.js
@@ -1,9 +1,10 @@
 /**
  * ElevenLabs Text-to-Speech helper.
  *
- * Generates a documentary-style voiceover narration for each blog post
- * using text from the post's "Did You Know?" section (newer posts) or
- * "Quick Facts" table (older posts).
+ * Generates a documentary-style voiceover narration for each blog post.
+ * Current posts prefer the first paragraph from the article's Overview
+ * section. Did You Know / Quick Facts remain the safe fallback for older or
+ * insufficient overview content.
  *
  * Uses the /with-timestamps endpoint to get word-level timing data
  * so video.js can render animated synchronized captions.
@@ -13,7 +14,7 @@
  *
  * Free plan: 10 000 chars/month.
  * Schedule: 1 video every 3 days ≈ 10 videos/month.
- * Avg narration: ~600 chars → ~6 000 chars/month (well within free tier).
+ * Avg narration: ~750 chars → ~7 500 chars/month (within the scheduled budget).
  *
  * Env vars required: ELEVENLABS_API_KEY (primary), ELEVENLABS_API_KEY_2 (fallback)
  * Fallback is used automatically when the primary account hits its 10k char/month quota.
@@ -32,12 +33,112 @@ const MODEL_IDS = [
   "eleven_flash_v2_5", // documented functional replacement for Turbo v2.5
 ];
 
+const OVERVIEW_NARRATION_LIMITS = Object.freeze({
+  minChars: 400,
+  maxChars: 1000,
+  minWords: 65,
+  maxWords: 150,
+  minSentences: 3,
+});
+
+const OVERVIEW_SOURCE_ARTIFACT_RE =
+  /\b(?:advertisement|click here|jump to navigation|plot synopsis|read more|related stories|table of contents)\b|https?:\/\/|www\./i;
+
+function normalizeNarrationText(value) {
+  return String(value || "").replace(/\s+/g, " ").trim();
+}
+
+function splitOverviewSentences(value) {
+  const clean = normalizeNarrationText(value);
+  if (!clean) return [];
+  const protectedText = clean
+    .replace(/\b[A-Z]\.(?:[A-Z]\.)*/g, (match) => match.replace(/\./g, "\u0001"))
+    .replace(
+      /\b(?:Dr|Mr|Mrs|Ms|Prof|St|Jr|Sr|Gen|Lt|Col|Capt|Sgt|Gov|Sen|Rep|Pres|No|Inc|Ltd|Co|Corp)\./gi,
+      (match) => match.replace(/\./g, "\u0001"),
+    );
+  return protectedText
+    .split(/(?<=[.!?])\s+/)
+    .map((sentence) => sentence.replace(/\u0001/g, ".").trim())
+    .filter(Boolean);
+}
+
+/**
+ * Checks whether an Overview paragraph is dense and bounded enough to become
+ * the narration verbatim. Topic matching is performed separately against the
+ * post metadata before TTS.
+ */
+export function assessOverviewNarration(value) {
+  const text = normalizeNarrationText(value);
+  const words = text ? text.split(/\s+/).filter(Boolean).length : 0;
+  const sentences = splitOverviewSentences(text);
+  const reasons = [];
+
+  if (text.length < OVERVIEW_NARRATION_LIMITS.minChars) {
+    reasons.push(`overview is shorter than ${OVERVIEW_NARRATION_LIMITS.minChars} characters`);
+  }
+  if (text.length > OVERVIEW_NARRATION_LIMITS.maxChars) {
+    reasons.push(`overview exceeds ${OVERVIEW_NARRATION_LIMITS.maxChars} characters`);
+  }
+  if (words < OVERVIEW_NARRATION_LIMITS.minWords) {
+    reasons.push(`overview has fewer than ${OVERVIEW_NARRATION_LIMITS.minWords} words`);
+  }
+  if (words > OVERVIEW_NARRATION_LIMITS.maxWords) {
+    reasons.push(`overview exceeds ${OVERVIEW_NARRATION_LIMITS.maxWords} words`);
+  }
+  if (sentences.length < OVERVIEW_NARRATION_LIMITS.minSentences) {
+    reasons.push(`overview has fewer than ${OVERVIEW_NARRATION_LIMITS.minSentences} sentences`);
+  }
+  if (!/\b(?:\d{1,4}(?:,\d{3})*|\d{1,4}\s*(?:BC|BCE|AD|CE))\b/i.test(text)) {
+    reasons.push("overview has no concrete date or number");
+  }
+  if (OVERVIEW_SOURCE_ARTIFACT_RE.test(text)) {
+    reasons.push("overview contains source or navigation residue");
+  }
+
+  return {
+    ok: reasons.length === 0,
+    text,
+    chars: text.length,
+    words,
+    sentences: sentences.length,
+    reasons,
+  };
+}
+
+/**
+ * Splits one verbatim Overview paragraph into two balanced timing/audit parts.
+ * Joining the parts with one space reconstructs the normalized paragraph.
+ */
+export function buildOverviewNarrationParts(value) {
+  const assessment = assessOverviewNarration(value);
+  if (!assessment.text) return [];
+  const sentences = splitOverviewSentences(assessment.text);
+  if (sentences.length < 2) return [assessment.text];
+
+  let splitAt = 1;
+  let smallestDifference = Infinity;
+  for (let index = 1; index < sentences.length; index += 1) {
+    const leftLength = sentences.slice(0, index).join(" ").length;
+    const rightLength = sentences.slice(index).join(" ").length;
+    const difference = Math.abs(leftLength - rightLength);
+    if (difference < smallestDifference) {
+      smallestDifference = difference;
+      splitAt = index;
+    }
+  }
+
+  return [
+    sentences.slice(0, splitAt).join(" "),
+    sentences.slice(splitAt).join(" "),
+  ].filter(Boolean);
+}
+
 /**
  * Builds the TTS narration script.
  *
- * Uses only the high-interest facts selected before this function is called.
- * The title supplies context; generic intros, source attributions, calls to
- * action, descriptions, and arbitrary first article paragraphs are excluded.
+ * Builds the fallback fact-card narration. Overview narration is prepared by
+ * buildOverviewNarrationParts before this fallback is reached.
  *
  * @param {{ title: string, description: string }} post
  * @param {string[]|null} contentItems  — DYK bullets or Quick Facts rows

--- a/youtube-upload/lib/kv.js
+++ b/youtube-upload/lib/kv.js
@@ -174,6 +174,53 @@ export async function getArticleText(slug) {
 }
 
 /**
+ * Extracts the first substantive paragraph from the explicitly marked
+ * Overview section. Current articles use this paragraph as a compact,
+ * chronological account of the anniversary event, which makes it a stronger
+ * narration source than disconnected fact cards.
+ *
+ * The marker is required deliberately: older or malformed pages fall back to
+ * the existing Did You Know / Quick Facts narration path instead of allowing
+ * navigation, metadata, or recommendation prose into ElevenLabs.
+ *
+ * @param {string} raw
+ * @returns {string|null}
+ */
+export function extractOverviewNarrationFromHtml(raw) {
+  const html = String(raw || "");
+  const markerIndex = html.indexOf("<!-- Overview -->");
+  if (markerIndex < 0) return null;
+
+  const afterMarker = html.slice(markerIndex + "<!-- Overview -->".length);
+  const section = afterMarker.match(/<section\b[^>]*>([\s\S]*?)<\/section>/i)?.[1];
+  if (!section) return null;
+
+  for (const match of section.matchAll(/<p\b([^>]*)>([\s\S]*?)<\/p>/gi)) {
+    const attrs = match[1] || "";
+    if (/\b(?:article-meta|dyn-fact|tdq-|amazon-|evidence-map)\b/i.test(attrs)) {
+      continue;
+    }
+    const text = decodeEntities(
+      match[2]
+        .replace(/<script\b[\s\S]*?<\/script>/gi, " ")
+        .replace(/<style\b[\s\S]*?<\/style>/gi, " ")
+        .replace(/<[^>]+>/g, " ")
+        .replace(/\s+/g, " ")
+        .trim(),
+    );
+    if (text.length >= 60) return text;
+  }
+
+  return null;
+}
+
+export async function getOverviewNarration(slug) {
+  const raw = await kvGet(`post:${slug}`);
+  if (!raw) return null;
+  return extractOverviewNarrationFromHtml(raw);
+}
+
+/**
  * Extracts wiki-hosted image URLs from the stored post HTML.
  * The blog content uses /image-proxy?src=... wrappers; this unwraps them
  * back to the original Wikimedia/Commons URL so the video pipeline can reuse

--- a/youtube-upload/lib/narration-selection.js
+++ b/youtube-upload/lib/narration-selection.js
@@ -396,7 +396,7 @@ export function auditNarrationTopicConnection(
   title,
   facts,
   topicContext = "",
-  { minimumFacts = 2 } = {},
+  { minimumFacts = 2, continuousNarrative = false } = {},
 ) {
   const items = (Array.isArray(facts) ? facts : [])
     .map((fact) => normalizeText(fact))
@@ -405,20 +405,38 @@ export function auditNarrationTopicConnection(
     text,
     ...narrationTopicConnection(text, title, topicContext),
   }));
-  return {
-    version: 1,
-    ok:
-      results.length >= minimumFacts &&
-      results.every((result) => result.connected) &&
-      results.some(
+  const joinedResult = continuousNarrative
+    ? {
+        text: items.join(" "),
+        ...narrationTopicConnection(items.join(" "), title, topicContext),
+      }
+    : null;
+  const hasTopicAnchor = continuousNarrative
+    ? Boolean(
+        joinedResult &&
+          (joinedResult.titleMatches.length > 0 ||
+            joinedResult.personMatches.length > 0 ||
+            joinedResult.contextMatches.length >= 2),
+      )
+    : results.some(
         (result) =>
           result.titleMatches.length > 0 ||
           result.personMatches.length > 0 ||
           result.contextMatches.length >= 2,
-      ),
+      );
+  return {
+    version: 1,
+    ok:
+      results.length >= minimumFacts &&
+      (continuousNarrative
+        ? joinedResult?.connected
+        : results.every((result) => result.connected)) &&
+      hasTopicAnchor,
     title: normalizeText(title),
     checkedFacts: results.length,
     minimumFacts,
+    continuousNarrative,
+    joinedResult,
     results,
   };
 }

--- a/youtube-upload/lib/narration-source.js
+++ b/youtube-upload/lib/narration-source.js
@@ -1,0 +1,99 @@
+import {
+  assessOverviewNarration,
+  buildNarrationParts,
+  buildOverviewNarrationParts,
+} from "./elevenlabs.js";
+import {
+  auditNarrationTopicConnection,
+  buildNarrationTopicContext,
+  selectInterestingNarrationFacts,
+} from "./narration-selection.js";
+import { videoHeadlineTitle, videoMatchTitle } from "./titles.js";
+
+/**
+ * Chooses the exact narration text without making an AI call.
+ *
+ * A sufficiently dense, topic-connected Overview paragraph wins. Current
+ * Overview paragraphs are already chronological miniature narratives and are
+ * kept verbatim. Older/thin/malformed articles retain the established
+ * Did You Know + Quick Facts selector.
+ */
+export function prepareNarrationSource(
+  post,
+  {
+    overviewText = null,
+    didYouKnow = [],
+    quickFacts = [],
+    articleText = null,
+  } = {},
+) {
+  const title = videoMatchTitle(post);
+  const topicContext = buildNarrationTopicContext(post, quickFacts);
+  const overviewAssessment = assessOverviewNarration(overviewText);
+
+  if (overviewAssessment.ok) {
+    const overviewParts = buildOverviewNarrationParts(overviewAssessment.text);
+    const overviewTopicAudit = auditNarrationTopicConnection(
+      title,
+      overviewParts,
+      topicContext,
+      { continuousNarrative: true },
+    );
+    if (overviewTopicAudit.ok) {
+      return {
+        source: "overview",
+        narrationParts: overviewParts,
+        contentItems: overviewParts,
+        topicContext,
+        topicAudit: overviewTopicAudit,
+        overviewAssessment,
+        fallbackItems: [],
+      };
+    }
+    overviewAssessment.reasons.push(
+      ...overviewTopicAudit.results
+        .filter((result) => !result.connected)
+        .map((result) => `overview topic check: ${result.reason}`),
+    );
+    overviewAssessment.ok = false;
+  }
+
+  const fallbackItems = [
+    ...(Array.isArray(didYouKnow) ? didYouKnow : []),
+    ...(Array.isArray(quickFacts) ? quickFacts : []),
+  ];
+  const selected = selectInterestingNarrationFacts(
+    title,
+    fallbackItems,
+    articleText,
+    {
+      limit: 3,
+      dateHint: videoHeadlineTitle(post),
+      topicContext,
+    },
+  );
+  const preparedParts = buildNarrationParts(post, selected);
+  const preparedAudit = auditNarrationTopicConnection(
+    title,
+    preparedParts,
+    topicContext,
+  );
+  const narrationParts = preparedAudit.results
+    .filter((result) => result.connected)
+    .map((result) => result.text);
+  const topicAudit = auditNarrationTopicConnection(
+    title,
+    narrationParts,
+    topicContext,
+  );
+
+  return {
+    source: "curated-facts",
+    narrationParts,
+    contentItems: selected,
+    topicContext,
+    topicAudit,
+    overviewAssessment,
+    fallbackItems,
+  };
+}

--- a/youtube-upload/lib/video.js
+++ b/youtube-upload/lib/video.js
@@ -47,9 +47,12 @@ if (!LORA_BOLD_EXISTS) console.warn("  ⚠ Lora-Bold.ttf not found — falling b
 // Custom background image for the title panel (1080×480, dark green textured bg)
 const TEXT_BG_PATH = join(dirname(fileURLToPath(import.meta.url)), "../assets/text-bg.png");
 /**
- * Single scene per video — one full-bleed image with pulsing zoom.
+ * Prefer three full-bleed article images. Articles with only two distinct,
+ * usable images still qualify as multi-scene; a one-image result fails closed.
  */
-const N_SCENES = 1;
+export const VIDEO_SCENE_COUNT = 3;
+export const MIN_MULTI_SCENE_IMAGES = 2;
+const N_SCENES = VIDEO_SCENE_COUNT;
 
 // Gentle crossfade only — slide/wipe transitions are too jarring for a calm history channel
 const XFADE_TRANSITIONS = ["fade"];
@@ -365,7 +368,12 @@ function getWikipediaTitleFromUrl(articleUrlOrTitle) {
   return raw;
 }
 
-async function fetchWikipediaImageBuffers(articleUrlOrTitle, count = 2, context = {}) {
+async function fetchWikipediaImageBuffers(
+  articleUrlOrTitle,
+  count = 2,
+  context = {},
+  seenIdentities = new Set(),
+) {
   const ua = { "User-Agent": "thisday.info-blog/1.0 (https://thisday.info)" };
   const buffers = [];
   const pageTitle = getWikipediaTitleFromUrl(articleUrlOrTitle);
@@ -436,8 +444,13 @@ async function fetchWikipediaImageBuffers(articleUrlOrTitle, count = 2, context 
       );
       for (const url of urls) {
         if (buffers.length >= count) break;
+        const identity = normalizeVideoImageIdentity(url);
+        if (identity && seenIdentities.has(identity)) continue;
         const buf = await downloadSafe(url);
-        if (buf) buffers.push(buf);
+        if (buf) {
+          buffers.push(buf);
+          if (identity) seenIdentities.add(identity);
+        }
       }
     }
   } catch {
@@ -841,7 +854,8 @@ export async function resolvePostImage(post) {
   );
 }
 
-const DURATION = 45; // seconds — max 45 s
+export const VIDEO_DURATION_LIMIT_S = 60;
+const DURATION = VIDEO_DURATION_LIMIT_S;
 const FPS = 30;
 
 // ---------------------------------------------------------------------------
@@ -1124,13 +1138,45 @@ async function downloadImageBuffer(url) {
   return Buffer.from(await res.arrayBuffer());
 }
 
-async function fetchArticleImageBuffers(slug, limit = 3) {
+export function normalizeVideoImageIdentity(value) {
+  let raw = String(value || "").trim();
+  if (!raw) return "";
+
+  try {
+    let parsed = new URL(raw, "https://thisday.info");
+    if (parsed.pathname.includes("/image-proxy")) {
+      const proxied = parsed.searchParams.get("src");
+      if (proxied) parsed = new URL(proxied);
+    }
+
+    let pathname = decodeURIComponent(parsed.pathname);
+    const thumbMarker = "/thumb/";
+    const thumbIndex = pathname.indexOf(thumbMarker);
+    if (thumbIndex >= 0) {
+      const prefix = pathname.slice(0, thumbIndex);
+      const parts = pathname.slice(thumbIndex + thumbMarker.length).split("/");
+      if (parts.length >= 4) pathname = `${prefix}/${parts.slice(0, -1).join("/")}`;
+    }
+    return `${parsed.hostname.toLowerCase()}${pathname}`;
+  } catch {
+    return raw.split(/[?#]/)[0].toLowerCase();
+  }
+}
+
+async function fetchArticleImageBuffers(
+  slug,
+  limit = 3,
+  seenIdentities = new Set(),
+) {
   const urls = await getPostImageUrls(slug, Math.max(limit * 4, 12));
   const buffers = [];
   for (const url of urls) {
+    const identity = normalizeVideoImageIdentity(url);
+    if (identity && seenIdentities.has(identity)) continue;
     try {
       const buf = await downloadImageBuffer(url);
       buffers.push(buf);
+      if (identity) seenIdentities.add(identity);
       if (buffers.length >= limit) break;
     } catch {
       // skip broken article images and keep going
@@ -1142,11 +1188,14 @@ async function fetchArticleImageBuffers(slug, limit = 3) {
 async function fetchPreferredVideoImageBuffers(post, articleSource, limit, context = {}) {
   const buffers = [];
   const featuredUrl = post?.imageUrl || null;
+  const seenIdentities = new Set();
 
   if (featuredUrl) {
     try {
       const featuredBuffer = await downloadImageBuffer(featuredUrl);
       buffers.push(featuredBuffer);
+      const identity = normalizeVideoImageIdentity(featuredUrl);
+      if (identity) seenIdentities.add(identity);
       console.log("  ✓ Using blog featured image as primary video image");
     } catch (err) {
       console.warn(`  ⚠ Featured image unavailable for video (${err.message}) — falling back to Wikipedia article images`);
@@ -1155,10 +1204,25 @@ async function fetchPreferredVideoImageBuffers(post, articleSource, limit, conte
 
   if (buffers.length >= limit) return buffers.slice(0, limit);
 
+  const articleBuffers = await fetchArticleImageBuffers(
+    post?.slug,
+    limit - buffers.length,
+    seenIdentities,
+  );
+  buffers.push(...articleBuffers);
+  if (articleBuffers.length > 0) {
+    console.log(
+      `  ✓ Added ${articleBuffers.length} distinct inline article image(s)`,
+    );
+  }
+
+  if (buffers.length >= limit) return buffers.slice(0, limit);
+
   const fallbackBuffers = await fetchWikipediaImageBuffers(
     articleSource,
     limit - buffers.length,
     context,
+    seenIdentities,
   );
   buffers.push(...fallbackBuffers);
   return buffers.slice(0, limit);
@@ -1383,7 +1447,7 @@ function extractPersonName(title) {
  * and leaves Zero GPU headroom for future WAN 2.2 I2V animation (3 clips ≈ 2.5 min/day).
  *
  * @param {string} title
- * @param {string[]|null} contentItems  DYK bullets / Quick Facts rows
+ * @param {string[]|null} contentItems  Overview timing parts or fallback fact rows
  * @param {string|null}   qualityHint   Remediation directive from a failed quality check
  * @returns {string[]}  3 prompts
  */
@@ -1557,7 +1621,7 @@ async function generateMultiSceneVideo(
   const XF = 1.2; // crossfade duration in seconds — longer = gentler on the eyes
 
   // Compute actual video duration from narration end + 3 s tail,
-  // capped at the 45 s max. Falls back to DURATION when no timestamps.
+  // capped at the 60 s Shorts target. Falls back to DURATION without timestamps.
   const narrEnd = words?.length > 0 ? words[words.length - 1].end : null;
   const videoDuration = narrEnd
     ? Math.max(Math.min(Math.ceil(narrEnd) + 3, DURATION), 10)
@@ -1583,10 +1647,14 @@ async function generateMultiSceneVideo(
     );
   }
 
-  const minWikiImages = Math.max(
-    1,
-    Number.parseInt(process.env.WIKI_IMAGE_MIN_COUNT || `${N_SCENES}`, 10) ||
-      N_SCENES,
+  const configuredMinWikiImages =
+    Number.parseInt(
+      process.env.WIKI_IMAGE_MIN_COUNT || `${MIN_MULTI_SCENE_IMAGES}`,
+      10,
+    ) || MIN_MULTI_SCENE_IMAGES;
+  const minWikiImages = Math.min(
+    N_SCENES,
+    Math.max(MIN_MULTI_SCENE_IMAGES, configuredMinWikiImages),
   );
 
   if (imageBuffers.length < minWikiImages) {

--- a/youtube-upload/preview.js
+++ b/youtube-upload/preview.js
@@ -6,16 +6,22 @@
  */
 
 import "dotenv/config";
-import { getPostIndex, getDidYouKnow, getQuickFacts, getArticleText, getPostWikipediaUrl } from "./lib/kv.js";
+import {
+  getArticleText,
+  getDidYouKnow,
+  getOverviewNarration,
+  getPostIndex,
+  getPostWikipediaUrl,
+  getQuickFacts,
+} from "./lib/kv.js";
 import { generateVideo } from "./lib/video.js";
-import { videoHeadlineTitle, videoMatchTitle } from "./lib/titles.js";
-import { generateNarration, buildNarrationParts } from "./lib/elevenlabs.js";
+import { videoMatchTitle } from "./lib/titles.js";
+import { generateNarration } from "./lib/elevenlabs.js";
 import {
   assessNarrationCaptionIntegrity,
   auditNarrationTopicConnection,
-  buildNarrationTopicContext,
-  selectInterestingNarrationFacts,
 } from "./lib/narration-selection.js";
+import { prepareNarrationSource } from "./lib/narration-source.js";
 import { getMusicPath } from "./lib/music.js";
 
 function getTodaySlug() {
@@ -39,27 +45,32 @@ async function main() {
   console.log(`Post: ${post.title}`);
 
   // Narration content
-  const [dyk, qf, articleText, wikiUrl] = await Promise.all([
+  const [overviewText, dyk, qf, articleText, wikiUrl] = await Promise.all([
+    getOverviewNarration(slug),
     getDidYouKnow(slug),
     getQuickFacts(slug),
     getArticleText(slug).catch(() => null),
     getPostWikipediaUrl(slug),
   ]);
-  const rawItems = [...(dyk || []), ...(qf || [])];
-  const topicContext = buildNarrationTopicContext(post, qf);
-  const selectedItems = selectInterestingNarrationFacts(
-    videoMatchTitle(post),
-    rawItems,
+  const narration = prepareNarrationSource(post, {
+    overviewText,
+    didYouKnow: dyk,
+    quickFacts: qf,
     articleText,
-    { limit: 3, dateHint: videoHeadlineTitle(post), topicContext },
+  });
+  const topicContext = narration.topicContext;
+  const narrationParts = narration.narrationParts;
+  const contentItems = narration.contentItems;
+  console.log(
+    narration.source === "overview"
+      ? `Narration source: Overview (${narration.overviewAssessment.words} words)`
+      : `Narration source: curated facts (${narration.overviewAssessment.reasons.join("; ")})`,
   );
-  const contentItems = selectedItems;
-  const narrationItems = selectedItems;
-  const narrationParts = buildNarrationParts(post, narrationItems);
   const topicAudit = auditNarrationTopicConnection(
     videoMatchTitle(post),
     narrationParts,
     topicContext,
+    { continuousNarrative: narration.source === "overview" },
   );
   if (!topicAudit.ok) {
     throw new Error(
@@ -83,7 +94,7 @@ async function main() {
     bgMusicPath,
     words,
     useAiImage,
-    contentItems: selectedItems,
+    contentItems,
     wikiArticleUrl: wikiUrl,
     narrationParts,
   });

--- a/youtube-upload/promote-reviewed.js
+++ b/youtube-upload/promote-reviewed.js
@@ -111,6 +111,7 @@ async function main() {
     title,
     storedAudit.facts,
     topicContext,
+    { continuousNarrative: storedAudit.source === "overview" },
   );
   const rebuiltScript = storedAudit.facts
     .map((fact) => String(fact || "").trim())
@@ -149,6 +150,7 @@ async function main() {
     title,
     storedAudit.facts,
     topicContext,
+    { continuousNarrative: storedAudit.source === "overview" },
   );
   const immediateVideoAudit = auditYoutubeVideo(
     post,

--- a/youtube-upload/test-video-text.js
+++ b/youtube-upload/test-video-text.js
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   extractArticleTextFromHtml,
   extractDidYouKnowFromHtml,
+  extractOverviewNarrationFromHtml,
   extractQuickFactsFromHtml,
 } from "./lib/kv.js";
 import {
@@ -13,12 +14,21 @@ import {
   selectInterestingNarrationFacts,
 } from "./lib/narration-selection.js";
 import {
+  assessOverviewNarration,
   buildNarrationParts,
   buildNarrationScript,
+  buildOverviewNarrationParts,
 } from "./lib/elevenlabs.js";
+import { prepareNarrationSource } from "./lib/narration-source.js";
 import { buildVideoTitle } from "./lib/titles.js";
 import { auditYoutubeVideo } from "./lib/youtube.js";
-import { buildSingleImageMotion } from "./lib/video.js";
+import {
+  buildSingleImageMotion,
+  MIN_MULTI_SCENE_IMAGES,
+  normalizeVideoImageIdentity,
+  VIDEO_DURATION_LIMIT_S,
+  VIDEO_SCENE_COUNT,
+} from "./lib/video.js";
 import {
   collectReplacedYoutubeIds,
   isUploadLockActive,
@@ -53,6 +63,127 @@ function testCurrentMarkupExtraction() {
     "Event: JFK Jr. plane crash",
     "Date: July 16, 1999",
   ]);
+}
+
+const OVERVIEW_NARRATION =
+  "On August 16, 1930, Ub Iwerks released Fiddlesticks, the first color sound cartoon. " +
+  "This 1930 American animated comedy short film was directed and animated by Ub Iwerks, featuring his character Flip the Frog. " +
+  "The short film utilized the short-lived Harriscolor process, making it the first complete individual sound cartoon to be photographed in color. " +
+  "Fiddlesticks was a significant release, as it marked a new milestone in animation technology. " +
+  "The film's plot revolves around Flip, who is seen dancing on lilypads until he reaches land and dries himself off. " +
+  "He then walks to a party, where he performs a dance for the audience, accidentally climbing to a spider web. " +
+  "The cartoon's use of color and sound added a new dimension to the animation, making it a notable achievement in the field. " +
+  "The film's release was a testament to Ub Iwerks' innovative approach to animation.";
+
+function testOverviewNarrationExtractionAndSelection() {
+  const html = `
+    <p class="article-meta">Published August 16, 2026.</p>
+    <!-- Overview -->
+    <section class="mt-4">
+      <h2>The Ceremony and the Signal</h2>
+      <figure><figcaption>Ub Iwerks</figcaption></figure>
+      <p>On August 16, 1930, <a href="https://en.wikipedia.org/wiki/Ub_Iwerks">Ub Iwerks</a> released Fiddlesticks, the first color sound cartoon. ${OVERVIEW_NARRATION.replace(/^On August 16, 1930, Ub Iwerks released Fiddlesticks, the first color sound cartoon\.\s*/, "")}</p>
+      <p>This second Overview paragraph must not be narrated.</p>
+    </section>
+    <!-- Personal Analysis -->`;
+  const extracted = extractOverviewNarrationFromHtml(html);
+  assert.equal(extracted, OVERVIEW_NARRATION);
+
+  const assessment = assessOverviewNarration(extracted);
+  assert.equal(assessment.ok, true);
+  assert.equal(assessment.words, 143);
+  assert.equal(assessment.sentences, 8);
+
+  const parts = buildOverviewNarrationParts(extracted);
+  assert.equal(parts.length, 2);
+  assert.equal(parts.join(" "), OVERVIEW_NARRATION);
+  assert.match(parts[0], /^On August 16, 1930/);
+
+  const post = {
+    title: "How did Ub Iwerks create the first color sound cartoon?",
+    eventTitle: "The first color sound cartoon, Fiddlesticks, is released by Ub Iwerks",
+    sourcePageTitle: "Fiddlesticks (1930 film)",
+    description: "Ub Iwerks released Fiddlesticks using Harriscolor.",
+  };
+  const prepared = prepareNarrationSource(post, {
+    overviewText: extracted,
+    quickFacts: [
+      "Event: The first color sound cartoon, Fiddlesticks, is released by Ub Iwerks",
+      "Key Figure: Ub Iwerks",
+    ],
+    didYouKnow: ["A fallback fact from 1930 that must not replace the Overview."],
+  });
+  assert.equal(prepared.source, "overview");
+  assert.equal(prepared.topicAudit.ok, true);
+  assert.equal(prepared.narrationParts.join(" "), OVERVIEW_NARRATION);
+}
+
+function testWeakOverviewFallsBackToCuratedFacts() {
+  const post = {
+    title: TITLE,
+    eventTitle: "John F. Kennedy Jr. dies in a plane crash",
+    sourcePageTitle: "John F. Kennedy Jr. plane crash",
+  };
+  const weak = "John F. Kennedy Jr. died in 1999.";
+  const prepared = prepareNarrationSource(post, {
+    overviewText: weak,
+    didYouKnow: LIVE_STYLE_FACTS,
+    quickFacts: [
+      "Event: John F. Kennedy Jr. dies in a plane crash",
+      "Date: July 16, 1999",
+    ],
+  });
+  assert.equal(prepared.source, "curated-facts");
+  assert.ok(prepared.overviewAssessment.reasons.some((reason) => /shorter|fewer/.test(reason)));
+  assert.ok(prepared.narrationParts.length >= 2);
+}
+
+function testOverviewSourceResidueFailsClosed() {
+  const contaminated = `${OVERVIEW_NARRATION} Plot synopsis: read more at https://example.com.`;
+  const assessment = assessOverviewNarration(contaminated);
+  assert.equal(assessment.ok, false);
+  assert.ok(assessment.reasons.some((reason) => /source or navigation residue/.test(reason)));
+}
+
+function testOverviewAuditPreservesNarrativeContext() {
+  const title = "Hawaii wildfires burn seventeen thousand acres";
+  const topicContext = {
+    text: "2023 Hawaii wildfires on Maui burned 17,000 acres",
+    coreText: "2023 Hawaii wildfires Maui",
+    personTerms: [],
+    locationText: "Maui, Hawaii",
+  };
+  const parts = [
+    "The 2023 Hawaii wildfires erupted on Maui in early August, scorching 17,000 acres and claiming at least 101 lives.",
+    "Emergency responders faced unprecedented challenges as the fires spread rapidly through densely populated areas.",
+  ];
+  assert.equal(
+    auditNarrationTopicConnection(title, parts, topicContext).ok,
+    false,
+  );
+  assert.equal(
+    auditNarrationTopicConnection(title, parts, topicContext, {
+      continuousNarrative: true,
+    }).ok,
+    true,
+  );
+}
+
+function testMultiImageVideoConfiguration() {
+  assert.equal(VIDEO_SCENE_COUNT, 3);
+  assert.equal(MIN_MULTI_SCENE_IMAGES, 2);
+  assert.equal(VIDEO_DURATION_LIMIT_S, 60);
+
+  const original =
+    "https://upload.wikimedia.org/wikipedia/commons/0/0c/Flip_the_Frog_-_Fiddlesticks_poster.jpg?utm_source=en.wikipedia.org";
+  const thumbnail =
+    "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0c/Flip_the_Frog_-_Fiddlesticks_poster.jpg/640px-Flip_the_Frog_-_Fiddlesticks_poster.jpg";
+  const proxiedThumbnail =
+    `https://thisday.info/image-proxy?src=${encodeURIComponent(thumbnail)}`;
+  assert.equal(
+    normalizeVideoImageIdentity(original),
+    normalizeVideoImageIdentity(proxiedThumbnail),
+  );
 }
 
 function testInterestingFactSelection() {
@@ -337,6 +468,11 @@ function testReplacementChainSurvivesConcurrentRetries() {
 }
 
 testCurrentMarkupExtraction();
+testOverviewNarrationExtractionAndSelection();
+testWeakOverviewFallsBackToCuratedFacts();
+testOverviewSourceResidueFailsClosed();
+testOverviewAuditPreservesNarrativeContext();
+testMultiImageVideoConfiguration();
 testInterestingFactSelection();
 testNarrationContainsFactsOnly();
 testAllFillerFailsClosed();


### PR DESCRIPTION
## What changed

- narrate the first informative Overview paragraph verbatim, with curated facts as a safe fallback
- validate Overview length, structure, source residue, and topic connection
- render up to three distinct article images, requiring at least two and deduplicating proxy/thumbnail variants
- raise the render cap from 45 to 60 seconds so 150-word narration is not truncated
- preserve source-aware topic checks during review promotion

## Why

The existing multi-scene renderer was hard-coded to one scene, and narration used disconnected fact cards. Today’s article supplies a strong 143-word Overview plus two distinct article images.

## Verification

- `node youtube-upload/test-video-text.js`
- `node --test tests/narration-selection.test.js tools/youtube-upload-workflow.test.js`
- `node --test tests/routes.test.js tests/schema.test.js` (607 passed)
- syntax and `git diff --check`
- GET-only live replay: all ten August 7–16 Overview paragraphs passed
- GET-only August 16 image audit: two distinct working Wikimedia images
