### PR TITLE
Harden AI fallbacks and video publishing

### DIFF
--- a/.github/workflows/youtube-upload.yml
+++ b/.github/workflows/youtube-upload.yml
@@ -112,7 +112,6 @@ jobs:
           BLOG_WORKER_URL: ${{ secrets.BLOG_WORKER_URL }}
           YOUTUBE_REGEN_SECRET: ${{ secrets.YOUTUBE_REGEN_SECRET }}
           USE_AI_IMAGE: ${{ secrets.USE_AI_IMAGE }}
-          WIKI_IMAGE_MIN_COUNT: ${{ secrets.WIKI_IMAGE_MIN_COUNT }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_TOKEN_2: ${{ secrets.HF_TOKEN_2 }}
           HF_TOKEN_3: ${{ secrets.HF_TOKEN_3 }}

--- a/js/shared/ai-call.js
+++ b/js/shared/ai-call.js
@@ -44,20 +44,12 @@
 import { resolveAiModel } from "./ai-model.js";
 
 const GROQ_URL = "https://api.groq.com/openai/v1/chat/completions";
-// Groq-announced shutdowns (https://console.groq.com/docs/deprecations):
-//   llama-3.3-70b-versatile                             → decommissions 2026-08-16
-//   llama-3.1-8b-instant                                → decommissions 2026-08-16
-//   meta-llama/llama-4-scout-17b-16e-instruct (vision)  → decommissions 2026-07-17
-//
-// llama-3.3-70b-versatile is STILL the primary model, not "already gone".
-// It is still active and has NOT been demoted for being on this list — see
-// the E2E lesson below. Do not pre-emptively hard-exclude a still-working
-// model just because a shutdown date is announced; Groq flips `active:false`
-// on its own /v1/models response at/near decommission, and rankTextModels()
-// already filters `active === false` — that is the whole self-healing point
-// (the runtime falls through to the next-ranked model automatically, no
-// deploy needed). A manual blocklist here just fights the score-based
-// ranking with no upside once the model IS truly gone.
+// Groq decommissioned llama-3.3-70b-versatile and llama-3.1-8b-instant on
+// 2026-08-16 (https://console.groq.com/docs/deprecations). GPT OSS 120B is
+// Groq's production replacement; Qwen 3.6 27B is retained as the next text
+// fallback. Permanently retired IDs are filtered even if a stale catalog
+// response still reports them active, and they are absent from the offline
+// fallback chain.
 //
 // E2E LESSON (2026-07-03): an earlier version of this file demoted
 // llama-3.3-70b-versatile's score and defaulted to openai/gpt-oss-120b
@@ -74,14 +66,14 @@ const GROQ_URL = "https://api.groq.com/openai/v1/chat/completions";
 // and so never revealed the problem. llama-3.3-70b-versatile is proven
 // reliable at real payload scale ("battle-tested for structured JSON at 4096
 // tokens" — the original design comment for its score bonus) and is kept as
-// primary until Groq's own catalog marks it inactive. gpt-oss-120b and
-// qwen3.6-27b remain strong secondary tiers (properly reasoning-gated) for
-// when llama-3.3 is genuinely retired or Groq's own rate limits kick in.
-const GROQ_MODEL = "llama-3.3-70b-versatile"; // hardcoded fallback if dynamic selection fails
+// primary until its announced shutdown. Now that the shutdown date has passed,
+// request-size protections below preserve that lesson while GPT OSS 120B and
+// Qwen 3.6 take over the active chain.
+const GROQ_MODEL = "openai/gpt-oss-120b"; // production fallback if dynamic selection fails
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
-// Same model as the Groq primary so quality/reliability doesn't drop when
-// Groq is rate-limited; ":free" variants cost nothing. `models` is
-// OpenRouter's server-side fallback chain (verified live 2026-07-03: a busy
+// OpenRouter has an independent model lifecycle, so Groq's retirement does not
+// imply that this provider-specific Llama entry is gone. `models` supplies a
+// GPT OSS server-side fallback chain (verified live 2026-07-03: a busy
 // 120b:free request was transparently served by 20b:free), ending in the
 // generic free router as last resort.
 const OPENROUTER_MODEL = "meta-llama/llama-3.3-70b-instruct:free";
@@ -550,15 +542,8 @@ function scoreModelForTextGen(modelId) {
   }
 
   // ── Architecture generation (recency / instruction-following quality) ──────
-  // Llama 3.3's +560 is deliberately larger than raw param count would give
-  // it (a 70b model otherwise loses to a 120b one on param score alone) —
-  // it is "battle-tested for structured JSON at 4096 tokens" AND, per the
-  // E2E lesson above this file's constants, has 12000 TPM on Groq's free
-  // tier vs 8000 for gpt-oss/qwen3.6-27b — real production payloads
-  // (source context + article JSON) need that headroom. Do not shrink this
-  // bonus again without re-running a full local publish E2E, not just a
-  // small-sample A/B test — small samples never hit the TPM ceiling that
-  // broke production here.
+  // The legacy Llama 3.3 score is retained only for deterministic ranking
+  // tests; rankTextModels() hard-excludes Groq's retired IDs below.
   if (/llama.?4/i.test(id))         score += 200; // Llama 4 — newest Meta arch
   else if (/llama.?3\.3/i.test(id)) score += 560; // Llama 3.3 — proven at real payload scale, 12000 TPM
   else if (/llama.?3\.1/i.test(id)) score += 40;  // Llama 3.1 — solid baseline
@@ -578,18 +563,17 @@ function scoreModelForTextGen(modelId) {
  */
 const _MIN_CONTEXT_WINDOW = 8_192;
 const _MIN_MAX_COMPLETION_TOKENS = 4_096;
-// Verified live against /v1/models on all 7 configured Groq keys (2026-07-22,
-// identical catalog across keys — same account). "qwen/qwen3-32b" (formerly
-// listed here) is no longer in the active catalog at all; "openai/gpt-oss-120b"
-// (score 1230, the actual #2 behind GROQ_MODEL's 1280) was missing. Ordered by
-// scoreModelForTextGen ranking so an emergency fallback (live query itself
-// failed) still tries models in the same order dynamic resolution would.
+const _GROQ_RETIRED_TEXT_MODELS = new Set([
+  "llama-3.3-70b-versatile",
+  "llama-3.1-8b-instant",
+]);
+
+// Offline emergency chain. It must contain only post-2026-08-16 active model
+// IDs because a failed catalog request cannot protect us from a retired ID.
 const _GROQ_FALLBACK_MODEL_CANDIDATES = [
   GROQ_MODEL,
-  "openai/gpt-oss-120b",
   "qwen/qwen3.6-27b",
   "openai/gpt-oss-20b",
-  "llama-3.1-8b-instant",
 ];
 
 function uniqueModelIds(models) {
@@ -604,18 +588,17 @@ function uniqueModelIds(models) {
  * Fields that are absent are treated as passing — the filter only fires when a
  * field is explicitly present and fails.
  *
- * Deliberately does NOT hard-exclude models by ID/deprecation announcement —
- * see the E2E lesson at GROQ_MODEL above. A model with an announced shutdown
- * date is still ranked normally by score until the provider's own `active`
- * flag flips false; that is what makes the fallback self-healing without a
- * deploy, per the original design intent.
+ * Announced deprecations remain selectable until their shutdown date. Once a
+ * model is permanently retired, its ID is added to
+ * _GROQ_RETIRED_TEXT_MODELS so stale catalog metadata cannot revive it.
  *
  * Filter order:
- *   1. active === false  → skip (Groq marks decommissioned models this way)
- *   2. context_window < 8192  → skip (prompt alone fills smaller windows)
- *   3. max_completion_tokens < 4096  → skip (can't emit full JSON output)
- *   4. scoreModelForTextGen < 0  → skip (audio, guard, TTS, compound models)
- *   5. Sort survivors by score descending
+ *   1. permanently retired ID  → skip
+ *   2. active === false  → skip
+ *   3. context_window < 8192  → skip (prompt alone fills smaller windows)
+ *   4. max_completion_tokens < 4096  → skip (can't emit full JSON output)
+ *   5. scoreModelForTextGen < 0  → skip (audio, guard, TTS, compound models)
+ *   6. Sort survivors by score descending
  *
  * @param {Array<{id:string, active?:boolean, context_window?:number, max_completion_tokens?:number}>} models
  * @returns {Array<{id:string, score:number}>}
@@ -623,6 +606,7 @@ function uniqueModelIds(models) {
 function rankTextModels(models) {
   return models
     .filter((m) => {
+      if (_GROQ_RETIRED_TEXT_MODELS.has(String(m.id || "").toLowerCase())) return false;
       if (m.active === false) return false;
       if (m.context_window != null && m.context_window < _MIN_CONTEXT_WINDOW) return false;
       if (m.max_completion_tokens != null && m.max_completion_tokens < _MIN_MAX_COMPLETION_TOKENS) return false;
@@ -635,7 +619,7 @@ function rankTextModels(models) {
 
 /**
  * Resolves Groq text model candidates at runtime.
- * Cache-first (module-level, 1h TTL). Falls back to GROQ_MODEL constant.
+ * Cache-first (module-level, 1h TTL). Falls back to the active offline chain.
  * @param {string} firstKey - First available Groq API key for the models query
  */
 async function resolveGroqModelCandidates(firstKey) {
@@ -694,12 +678,15 @@ function orderGroqModelsForRequest(models, messages, maxTokens) {
   const isLargeStructuredRequest = promptChars >= 6000 || maxTokens >= 3000;
   if (!isLargeStructuredRequest) return models;
   const primary = [];
-  const deferred = [];
+  const deferred120b = [];
+  const lightweight = [];
   for (const model of models) {
-    if (String(model).toLowerCase() === "openai/gpt-oss-120b") deferred.push(model);
+    const id = String(model).toLowerCase();
+    if (id === "openai/gpt-oss-120b") deferred120b.push(model);
+    else if (id === "openai/gpt-oss-20b") lightweight.push(model);
     else primary.push(model);
   }
-  return [...primary, ...deferred];
+  return [...primary, ...deferred120b, ...lightweight];
 }
 
 /**
@@ -756,9 +743,8 @@ export function reasoningCompletionBudget(modelId, maxTokens) {
  * some drift and re-verifying via a live request's response headers is the
  * source of truth if 413s reappear.
  *
- * llama-3.3-70b-versatile (12000 TPM, the primary model) normally has enough
- * headroom for our configured jobs. It is included so very large prompts can
- * still be capped before Groq rejects the request.
+ * The retired Llama 3.3 ceiling remains recognized for historical tests and
+ * diagnostics, but the selector can no longer return that model.
  *
  * @param {string} modelId
  * @returns {number|null}  TPM ceiling, or null if unknown/uncapped

--- a/tools/article-capacity-resume.test.js
+++ b/tools/article-capacity-resume.test.js
@@ -12,6 +12,11 @@ import {
   callWorkersAIDirect,
   isAIProviderCapacityError,
 } from "../js/shared/ai-call.js";
+import {
+  GROQ_TEXT_MODEL_DEFAULT as YOUTUBE_GROQ_TEXT_MODEL_DEFAULT,
+  __resetGroqModelResolverForTests as resetYoutubeGroqModelResolverForTests,
+  resolveGroqModels as resolveYoutubeGroqModels,
+} from "../youtube-upload/lib/model-resolver.js";
 
 function makeKvMock() {
   const store = new Map();
@@ -699,7 +704,7 @@ test("Groq-only request-size failures remain structural errors", async () => {
     const value = String(url);
     if (value.endsWith("/v1/models")) {
       return new Response(JSON.stringify({
-        data: [{ id: "llama-3.3-70b-versatile", active: true }],
+        data: [{ id: "openai/gpt-oss-120b", active: true }],
       }), { status: 200, headers: { "content-type": "application/json" } });
     }
     if (value.includes("api.groq.com/openai/v1/chat/completions")) {
@@ -728,6 +733,165 @@ test("Groq-only request-size failures remain structural errors", async () => {
     assert.match(failure.message, /request too large/i);
   } finally {
     globalThis.fetch = originalFetch;
+  }
+});
+
+test("retired Groq text models cannot be revived by stale active catalog data", async () => {
+  __resetGroqModelCacheForTests();
+  const originalFetch = globalThis.fetch;
+  let requestBody = null;
+  globalThis.fetch = async (url, init) => {
+    const value = String(url);
+    if (value.endsWith("/v1/models")) {
+      return new Response(JSON.stringify({
+        data: [
+          { id: "llama-3.3-70b-versatile", active: true, context_window: 131072, max_completion_tokens: 32768 },
+          { id: "llama-3.1-8b-instant", active: true, context_window: 131072, max_completion_tokens: 8192 },
+          { id: "openai/gpt-oss-120b", active: true, context_window: 131072, max_completion_tokens: 65536 },
+        ],
+      }), { status: 200, headers: { "content-type": "application/json" } });
+    }
+    if (value.includes("api.groq.com/openai/v1/chat/completions")) {
+      requestBody = JSON.parse(init.body);
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: "replacement-ok" } }],
+      }), { status: 200, headers: { "content-type": "application/json" } });
+    }
+    throw new Error(`unexpected fetch: ${value}`);
+  };
+  try {
+    assert.equal(
+      await callAI(
+        { ARTICLE_AI_PROVIDER_MODE: "groq-only", GROQ_API_KEY: "stale-catalog-key" },
+        [{ role: "user", content: "use an active model" }],
+        { providerAttemptLimit: 1 },
+      ),
+      "replacement-ok",
+    );
+    assert.equal(requestBody.model, "openai/gpt-oss-120b");
+    assert.equal(requestBody.reasoning_effort, "low");
+  } finally {
+    globalThis.fetch = originalFetch;
+    __resetGroqModelCacheForTests();
+  }
+});
+
+test("large Groq requests prefer Qwen 3.6 before the reasoning-heavy GPT OSS model", async () => {
+  __resetGroqModelCacheForTests();
+  const originalFetch = globalThis.fetch;
+  let requestBody = null;
+  globalThis.fetch = async (url, init) => {
+    const value = String(url);
+    if (value.endsWith("/v1/models")) {
+      return new Response(JSON.stringify({
+        data: [
+          { id: "openai/gpt-oss-120b", active: true, context_window: 131072, max_completion_tokens: 65536 },
+          { id: "qwen/qwen3.6-27b", active: true, context_window: 131072, max_completion_tokens: 16384 },
+          { id: "openai/gpt-oss-20b", active: true, context_window: 131072, max_completion_tokens: 65536 },
+        ],
+      }), { status: 200, headers: { "content-type": "application/json" } });
+    }
+    if (value.includes("api.groq.com/openai/v1/chat/completions")) {
+      requestBody = JSON.parse(init.body);
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: "large-request-ok" } }],
+      }), { status: 200, headers: { "content-type": "application/json" } });
+    }
+    throw new Error(`unexpected fetch: ${value}`);
+  };
+  try {
+    assert.equal(
+      await callAI(
+        { ARTICLE_AI_PROVIDER_MODE: "groq-only", GROQ_API_KEY: "large-request-key" },
+        [{ role: "user", content: "produce structured article JSON" }],
+        { maxTokens: 4096, providerAttemptLimit: 1 },
+      ),
+      "large-request-ok",
+    );
+    assert.equal(requestBody.model, "qwen/qwen3.6-27b");
+    assert.equal(requestBody.reasoning_effort, "none");
+    assert.equal(requestBody.reasoning_format, "hidden");
+  } finally {
+    globalThis.fetch = originalFetch;
+    __resetGroqModelCacheForTests();
+  }
+});
+
+test("Groq catalog failure falls back directly to GPT OSS 120B", async () => {
+  __resetGroqModelCacheForTests();
+  const originalFetch = globalThis.fetch;
+  let requestBody = null;
+  globalThis.fetch = async (url, init) => {
+    const value = String(url);
+    if (value.endsWith("/v1/models")) {
+      return new Response("catalog unavailable", { status: 503 });
+    }
+    if (value.includes("api.groq.com/openai/v1/chat/completions")) {
+      requestBody = JSON.parse(init.body);
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: "offline-chain-ok" } }],
+      }), { status: 200, headers: { "content-type": "application/json" } });
+    }
+    throw new Error(`unexpected fetch: ${value}`);
+  };
+  try {
+    assert.equal(
+      await callAI(
+        { ARTICLE_AI_PROVIDER_MODE: "groq-only", GROQ_API_KEY: "offline-catalog-key" },
+        [{ role: "user", content: "use the emergency model chain" }],
+        { providerAttemptLimit: 1 },
+      ),
+      "offline-chain-ok",
+    );
+    assert.equal(requestBody.model, "openai/gpt-oss-120b");
+    assert.equal(requestBody.reasoning_effort, "low");
+  } finally {
+    globalThis.fetch = originalFetch;
+    __resetGroqModelCacheForTests();
+  }
+});
+
+test("the YouTube pipeline defaults to GPT OSS 120B without a catalog", async () => {
+  const keyNames = ["GROQ_API_KEY", "GROQ_API_KEY_2", "GROQ_API_KEY_3", "GROQ_API_KEY_4"];
+  const originalKeys = Object.fromEntries(keyNames.map((name) => [name, process.env[name]]));
+  try {
+    for (const name of keyNames) delete process.env[name];
+    resetYoutubeGroqModelResolverForTests();
+    assert.equal(YOUTUBE_GROQ_TEXT_MODEL_DEFAULT, "openai/gpt-oss-120b");
+    assert.equal((await resolveYoutubeGroqModels()).textModel, "openai/gpt-oss-120b");
+  } finally {
+    for (const name of keyNames) {
+      if (originalKeys[name] == null) delete process.env[name];
+      else process.env[name] = originalKeys[name];
+    }
+    resetYoutubeGroqModelResolverForTests();
+  }
+});
+
+test("the YouTube pipeline rejects retired Llama IDs from stale catalog data", async () => {
+  const keyNames = ["GROQ_API_KEY", "GROQ_API_KEY_2", "GROQ_API_KEY_3", "GROQ_API_KEY_4"];
+  const originalKeys = Object.fromEntries(keyNames.map((name) => [name, process.env[name]]));
+  const originalFetch = globalThis.fetch;
+  try {
+    process.env.GROQ_API_KEY = "youtube-stale-catalog-key";
+    for (const name of keyNames.slice(1)) delete process.env[name];
+    globalThis.fetch = async () => new Response(JSON.stringify({
+      data: [
+        { id: "llama-3.3-70b-versatile" },
+        { id: "llama-3.1-8b-instant" },
+        { id: "openai/gpt-oss-120b" },
+        { id: "qwen/qwen3.6-27b" },
+      ],
+    }), { status: 200, headers: { "content-type": "application/json" } });
+    resetYoutubeGroqModelResolverForTests();
+    assert.equal((await resolveYoutubeGroqModels()).textModel, "openai/gpt-oss-120b");
+  } finally {
+    globalThis.fetch = originalFetch;
+    for (const name of keyNames) {
+      if (originalKeys[name] == null) delete process.env[name];
+      else process.env[name] = originalKeys[name];
+    }
+    resetYoutubeGroqModelResolverForTests();
   }
 });
 

--- a/tools/automatic-article-enrichment.test.js
+++ b/tools/automatic-article-enrichment.test.js
@@ -42,6 +42,20 @@ function queuedCompanion() {
   };
 }
 
+function eligibleEvergreenCompanion() {
+  return {
+    type: "event",
+    slug: "example-event-1969",
+    name: "Example Event",
+    wikiUrl: "https://en.wikipedia.org/wiki/Example",
+    url: "/history/example-event-1969/",
+    historyQualityGateVersion: 2,
+    historyCardQualified: true,
+    historyLinkEligible: true,
+    evergreenHistoryVersion: 1,
+  };
+}
+
 test("event fallbacks omit unsupported significance prose instead of filling space", () => {
   const entity = {
     type: "event",
@@ -92,7 +106,7 @@ test("event fallbacks omit unsupported significance prose instead of filling spa
   );
 });
 
-test("short event leads reuse validated article copy so the evergreen card does not depend on AI capacity", () => {
+test("short event leads reuse validated article copy without bypassing the evergreen edition gate", () => {
   const articleParagraph = Array.from(
     { length: 125 },
     (_, index) => `grounded${index}`,
@@ -125,7 +139,7 @@ test("short event leads reuse validated article copy so the evergreen card does 
   assert.ok(words >= 150, `expected at least 150 fallback words, got ${words}`);
   assert.equal(
     hooks.blogEntityQualityEligible({ ...entity, bodySections: sections }),
-    true,
+    false,
   );
 });
 
@@ -309,7 +323,10 @@ test("outbox completion waits for every asynchronous target", async () => {
   const store = new Map([
     ["post:20-july-2026", html],
     ["quiz-v3:blog:20-july-2026", JSON.stringify(quiz)],
-    ["post-entities:20-july-2026", "[]"],
+    [
+      "post-entities:20-july-2026",
+      JSON.stringify([eligibleEvergreenCompanion()]),
+    ],
   ]);
   const env = {
     BLOG_AI_KV: {
@@ -371,7 +388,10 @@ test("an already-complete retained outbox is cleared without rerunning enrichmen
         '<a data-history-entity-link="1" href="/history/example/"></a></article>',
     ],
     [`quiz-v3:blog:${slug}`, JSON.stringify(quiz)],
-    [`post-entities:${slug}`, "[]"],
+    [
+      `post-entities:${slug}`,
+      JSON.stringify([eligibleEvergreenCompanion()]),
+    ],
     ["index", JSON.stringify([{ slug }])],
   ]);
   let deletes = 0;
@@ -428,7 +448,10 @@ test("completed outbox cleanup failures remain observable and retryable", async 
         '<a data-history-entity-link="1" href="/history/example/"></a></article>',
     ],
     [`quiz-v3:blog:${slug}`, JSON.stringify(quiz)],
-    [`post-entities:${slug}`, "[]"],
+    [
+      `post-entities:${slug}`,
+      JSON.stringify([eligibleEvergreenCompanion()]),
+    ],
   ]);
   const env = {
     BLOG_AI_KV: {

--- a/wrangler-blog.jsonc
+++ b/wrangler-blog.jsonc
@@ -48,7 +48,8 @@
     // organizations/projects. Empty means one shared pool and disables
     // concurrent Groq article chunks, preventing parallel TPM exhaustion.
     // Verified independent 2026-08-05: all 7 keys answered a live request
-    // against llama-3.3-70b-versatile within minutes of that model's org
+    // against the then-active Llama 3.3 70B model within minutes of that
+    // model's org
     // reporting "Used 98746/100000" TPD for the key-1 account — the other
     // six were untouched. Before this, an empty value meant every key
     // shared one "groq:shared" circuit, so one account's TPD exhaustion

--- a/youtube-upload/index.js
+++ b/youtube-upload/index.js
@@ -6,8 +6,8 @@
  *
  * Audio:  ElevenLabs TTS narration (article Overview first, with Did You Know /
  *         Quick Facts fallback) mixed with background music at 33% volume.
- * Image:  Multi-scene mode. Uses the post's featured and inline article
- *         images first, then the exact Wikipedia article as a fallback.
+ * Image:  Uses only the post's own featured and inline article images. A post
+ *         with one image gets one continuous scene; up to three are used.
  * Schedule: Mon/Tue/Thu/Fri via GitHub Actions cron at 13:00 UTC
  *           (about 09:00 Eastern during daylight saving time)
  *
@@ -21,7 +21,6 @@
  *   BLOG_WORKER_URL        (needed when this job must trigger /blog/publish)
  *   YOUTUBE_REGEN_SECRET   (auth for POST /blog/publish regeneration)
  *   YOUTUBE_PRIVACY        (optional: private or public, default public)
- *   WIKI_IMAGE_MIN_COUNT   (optional: min usable wiki images for multi-scene video; default 3)
  *   ALLOW_SILENT_VIDEO     (optional: true only for deliberate music-only uploads)
  *
  * Optional expert-model fallbacks used by helper modules:
@@ -38,7 +37,6 @@ import {
   getQuickFacts,
   getArticleText,
   getOverviewNarration,
-  getPostWikipediaUrl,
   updateIndexEntry,
   deleteIndexEntry,
 } from "./lib/kv.js";
@@ -363,9 +361,6 @@ async function main() {
           getQuickFacts(post.slug),
           getArticleText(post.slug).catch(() => null),
         ]);
-        const wikiArticleUrl = await getPostWikipediaUrl(post.slug).catch(
-          () => null,
-        );
         const narration = prepareNarrationSource(post, {
           overviewText,
           didYouKnow: dykItems,
@@ -445,9 +440,9 @@ async function main() {
         }
 
         // ── Image pre-check ────────────────────────────────────────────────────
-        // Multi-scene mode builds from article/Wikipedia images instead of a
-        // single stored post.imageUrl, so the legacy resolvePostImage check is
-        // only needed for the single-scene fallback path.
+        // Article-image mode reads only the exact post's own images instead of
+        // accepting unrelated page thumbnails. The legacy resolvePostImage
+        // check is only needed for the explicit single-image legacy path.
         const useAiImage = process.env.USE_AI_IMAGE !== "false";
         if (!useAiImage) {
           console.log("  Checking image...");
@@ -461,7 +456,7 @@ async function main() {
             console.log("  ✓ Image OK");
           }
         } else {
-          console.log("  Multi-scene wiki mode — skipping single-image pre-check.");
+          console.log("  Exact-article image mode — skipping legacy image pre-check.");
         }
 
         // ── Generate video (with quality gate + retry) ─────────────────────────
@@ -481,8 +476,6 @@ async function main() {
             bgMusicPath,
             words: narrWords,
             useAiImage,
-            contentItems: narrationContentItems,
-            wikiArticleUrl,
             narrationParts,
             qualityHint,
           });

--- a/youtube-upload/lib/history-expert.js
+++ b/youtube-upload/lib/history-expert.js
@@ -6,7 +6,7 @@ import { resolveGroqModels, resolveHFTextModel, groqReasoningParams, reasoningCo
  * accuracy before sending to FLUX / HuggingFace image generation.
  *
  * Provider fallback chain (first available key wins):
- *   1. Groq  — best free model auto-resolved via resolveGroqModels() (default: llama-3.3-70b-versatile)
+ *   1. Groq  — best free model auto-resolved via resolveGroqModels() (default: openai/gpt-oss-120b)
  *              Keys: GROQ_API_KEY → GROQ_API_KEY_2 → GROQ_API_KEY_3 → GROQ_API_KEY_4
  *   2. HuggingFace — best free instruct model auto-resolved via resolveHFTextModel()
  *              (default: meta-llama/Llama-3.3-70B-Instruct via unified router.huggingface.co/v1)

--- a/youtube-upload/lib/kv.js
+++ b/youtube-upload/lib/kv.js
@@ -221,24 +221,39 @@ export async function getOverviewNarration(slug) {
 }
 
 /**
- * Extracts wiki-hosted image URLs from the stored post HTML.
- * The blog content uses /image-proxy?src=... wrappers; this unwraps them
- * back to the original Wikimedia/Commons URL so the video pipeline can reuse
- * the exact article images.
+ * Extracts the featured image and floated inline figures from one stored blog
+ * article. Recommendation cards, quiz artwork, companion cards, and other
+ * page chrome are deliberately excluded so a video can never mix imagery from
+ * different articles.
  *
- * @param {string} slug
+ * The blog uses /image-proxy?src=... wrappers; this unwraps them back to the
+ * original Wikimedia URL before returning the ordered, deduplicated list.
+ *
+ * @param {string} raw
  * @param {number} [limit=15]
- * @returns {Promise<string[]>}
+ * @returns {string[]}
  */
-export async function getPostImageUrls(slug, limit = 15) {
-  const raw = await kvGet(`post:${slug}`);
-  if (!raw) return [];
+export function extractPostArticleImageUrls(raw, limit = 15) {
+  if (!raw || limit <= 0) return [];
 
   const urls = [];
   const seen = new Set();
-  const imgRe = /<img\b[^>]*\bsrc\s*=\s*["']([^"']+)["'][^>]*>/gi;
-  for (const match of raw.matchAll(imgRe)) {
-    let src = decodeEntities(match[1]);
+  const figureRe = /<figure\b[^>]*>[\s\S]*?<\/figure>/gi;
+  const articleFigures = [...raw.matchAll(figureRe)]
+    .map((match) => match[0])
+    .filter((figure) => {
+      const openingTag = figure.match(/^<figure\b[^>]*>/i)?.[0] || "";
+      return (
+        /\bclass\s*=\s*["'][^"']*\barticle-hero-fig\b/i.test(openingTag) ||
+        /\bstyle\s*=\s*["'][^"']*\bfloat\s*:\s*(?:left|right)\b/i.test(openingTag)
+      );
+    });
+
+  for (const figure of articleFigures) {
+    const imgMatch = figure.match(
+      /<img\b[^>]*\bsrc\s*=\s*["']([^"']+)["'][^>]*>/i,
+    );
+    let src = decodeEntities(imgMatch?.[1] || "");
     if (!src) continue;
 
     try {
@@ -278,6 +293,18 @@ export async function getPostImageUrls(slug, limit = 15) {
   }
 
   return urls;
+}
+
+/**
+ * Reads one stored article and returns only its own featured/inline images.
+ *
+ * @param {string} slug
+ * @param {number} [limit=15]
+ * @returns {Promise<string[]>}
+ */
+export async function getPostImageUrls(slug, limit = 15) {
+  const raw = await kvGet(`post:${slug}`);
+  return extractPostArticleImageUrls(raw, limit);
 }
 
 /**

--- a/youtube-upload/lib/model-resolver.js
+++ b/youtube-upload/lib/model-resolver.js
@@ -4,47 +4,46 @@
  * available free model, and caches the result for the process lifetime.
  *
  * Groq fallbacks:
- *   text:   llama-3.3-70b-versatile
+ *   text:   openai/gpt-oss-120b
  *   vision: meta-llama/llama-4-scout-17b-16e-instruct (Groq shutdown 2026-07-17;
  *           NVIDIA NIM meta/llama-4-maverick-17b-128e-instruct is the fallback)
  *
  * HuggingFace fallback:
- *   text:   meta-llama/Llama-3.3-70B-Instruct  (unified router.huggingface.co/v1 — same model as Groq)
+ *   text:   meta-llama/Llama-3.3-70B-Instruct  (independent HF lifecycle)
  */
 
 const GROQ_MODELS_URL = "https://api.groq.com/openai/v1/models";
 
 // E2E lesson (2026-07-03, see js/shared/ai-call.js for the full writeup):
-// llama-3.3-70b-versatile stays primary even though Groq announced its
-// 2026-08-16 shutdown. It is not excluded here — a full local publish E2E
-// with gpt-oss-120b as primary hit repeated Groq 413 "Request too large" on
+// a full local publish E2E with gpt-oss-120b as primary hit repeated Groq 413
+// "Request too large" on
 // EVERY request, because this account's TPM allocation for gpt-oss-120b/20b
 // and qwen3.6-27b is only 8000 tokens/minute (6000 for qwen3-32b) vs 12000
 // for llama-3.3-70b-versatile. Real payloads (source context, prompt review,
 // image-review vision prompts) can exceed 8000 tokens in one request; a
 // small-sample A/B test never reveals this because it never uses a large
-// enough payload. Do not re-promote gpt-oss/qwen3 above llama-3.3 without
-// re-testing against a real, large payload — not just a short A/B sample.
-export const GROQ_TEXT_MODEL_DEFAULT   = "llama-3.3-70b-versatile";
+// enough payload. Llama 3.3 is now retired, so GPT OSS 120B is the production
+// default and request-time token capping remains mandatory for real payloads.
+export const GROQ_TEXT_MODEL_DEFAULT   = "openai/gpt-oss-120b";
 export const GROQ_VISION_MODEL_DEFAULT = "meta-llama/llama-4-scout-17b-16e-instruct";
 
 // Confirmed free text models on Groq free tier — checked in priority order.
 // Only models on this list are eligible; paid/preview/namespaced models are
 // never selected even if they appear in the API response.
-// Groq shutdowns (https://console.groq.com/docs/deprecations):
-//   llama-3.3-70b-versatile + llama-3.1-8b-instant → decommission 2026-08-16;
-//   llama-3.1-70b-versatile / llama-3-70b-8192 are already gone from the catalog.
-// Still first-choice until Groq's own catalog marks it inactive — see the
-// E2E lesson above. gpt-oss/qwen3.6 are strong fallback tiers (lower TPM
-// budget on this account, but fine for smaller per-call payloads).
+// llama-3.3-70b-versatile and llama-3.1-8b-instant were decommissioned on
+// 2026-08-16 and must not appear in this list. GPT OSS 120B is Groq's current
+// production replacement; Qwen 3.6 27B remains the next fallback.
 // Update this list when Groq adds new free models.
 const FREE_TEXT_MODEL_PRIORITY = [
-  "llama-3.3-70b-versatile", // primary — proven at real payload scale, 12000 TPM
-  "openai/gpt-oss-120b",     // fallback — 8000 TPM on this account
+  "openai/gpt-oss-120b",     // production replacement — 8000 TPM on this account
   "qwen/qwen3.6-27b",        // fallback — 8000 TPM (needs reasoning_format hidden + reasoning_effort none)
   "openai/gpt-oss-20b",      // lighter fallback, free
-  "qwen/qwen3-32b",          // additional fallback, free (6000 TPM)
 ];
+
+const RETIRED_GROQ_TEXT_MODELS = new Set([
+  "llama-3.3-70b-versatile",
+  "llama-3.1-8b-instant",
+]);
 
 // Confirmed free vision-capable models on Groq — checked in priority order.
 // llama-4-scout is Groq's ONLY remaining vision model and decommissions
@@ -149,9 +148,8 @@ export function reasoningCompletionBudget(modelId, maxTokens) {
  * Per-model Groq TPM (tokens/minute) ceiling, live-verified on this account
  * 2026-07-03. Groq-specific — do NOT reuse for HuggingFace, which runs its
  * own unrelated rate-limit system. Mirrors groqModelTpmLimit in
- * js/shared/ai-call.js; keep the two in sync. llama-3.3-70b-versatile
- * (12000 TPM, the primary model) normally has enough headroom, but very large
- * prompts still get capped before Groq rejects the request.
+ * js/shared/ai-call.js; keep the two in sync. The retired Llama 3.3 ceiling
+ * remains recognized only for historical diagnostics; selection excludes it.
  *
  * @param {string} modelId
  * @returns {number|null}
@@ -268,6 +266,10 @@ async function fetchModelIds(apiKey) {
 
 let _cache = null;
 
+export function __resetGroqModelResolverForTests() {
+  _cache = null;
+}
+
 /**
  * Resolves the best available Groq text and vision model IDs.
  * Queries the Groq models API once and caches for the process lifetime.
@@ -305,13 +307,16 @@ export async function resolveGroqModels() {
     return (_cache = { textModel: GROQ_TEXT_MODEL_DEFAULT, visionModel: GROQ_VISION_MODEL_DEFAULT });
   }
 
-  const modelSet = new Set(modelIds);
+  const activeTextModelIds = modelIds.filter(
+    (id) => !RETIRED_GROQ_TEXT_MODELS.has(String(id).toLowerCase()),
+  );
+  const modelSet = new Set(activeTextModelIds);
 
   // Best text model: prefer confirmed free models in priority order.
   // If none are available (e.g. Groq changes lineup), fall back to scoring
   // whatever is in the catalog so the pipeline keeps working.
   const freeText = FREE_TEXT_MODEL_PRIORITY.find((id) => modelSet.has(id));
-  const textModel = freeText ?? modelIds
+  const textModel = freeText ?? activeTextModelIds
     .filter((id) => !/whisper|guard|speech|tts|embedding/i.test(id))
     .sort((a, b) => scoreTextModel(b) - scoreTextModel(a))[0] ?? GROQ_TEXT_MODEL_DEFAULT;
 
@@ -331,13 +336,8 @@ export async function resolveGroqModels() {
 // ===========================================================================
 
 // Unified HF router (OpenAI-compatible): the model travels in the request
-// body and HF picks a serving provider. This serves the SAME
-// llama-3.3-70b-versatile as the Groq primary, so quality/reliability holds
-// when Groq rate-limits. HF's TPM policy is unrelated to Groq's — the
-// gpt-oss/qwen TPM ceiling that demoted them to fallback tier on Groq (see
-// GROQ_TEXT_MODEL_DEFAULT above) does not necessarily apply here, but
-// leading with the model already proven at real payload scale keeps this
-// path consistent and low-risk regardless.
+// body and HF picks a serving provider. HuggingFace has its own model catalog
+// and lifecycle, so Groq's Llama 3.3 retirement does not remove the HF entry.
 const HF_ROUTER_MODELS_URL = "https://router.huggingface.co/v1/models";
 const HF_ROUTER_CHAT_URL = "https://router.huggingface.co/v1/chat/completions";
 

--- a/youtube-upload/lib/narration-expert.js
+++ b/youtube-upload/lib/narration-expert.js
@@ -10,7 +10,7 @@ import { isInterestingNarrationFact } from "./narration-selection.js";
  * selected facts. It must not introduce additional claims.
  *
  * Provider fallback chain (first available key wins):
- *   1. Groq  — best free model auto-resolved via resolveGroqModels() (default: llama-3.3-70b-versatile)
+ *   1. Groq  — best free model auto-resolved via resolveGroqModels() (default: openai/gpt-oss-120b)
  *              Keys: GROQ_API_KEY → GROQ_API_KEY_2 → GROQ_API_KEY_3 → GROQ_API_KEY_4
  *   2. HuggingFace — best free instruct model auto-resolved via resolveHFTextModel()
  *              Tokens: HF_TOKEN → HF_TOKEN_2 → HF_TOKEN_3 → HF_TOKEN_4

--- a/youtube-upload/lib/notify.js
+++ b/youtube-upload/lib/notify.js
@@ -1,4 +1,12 @@
-import { statSync, readFileSync } from "fs";
+import { execFileSync } from "child_process";
+import {
+  mkdtempSync,
+  statSync,
+  readFileSync,
+  rmSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 import { videoHeadlineTitle } from "./titles.js";
 
 /**
@@ -15,10 +23,9 @@ import { videoHeadlineTitle } from "./titles.js";
  *
  * If neither is set this function is a silent no-op — safe to call always.
  *
- * Video delivery chain (all full-resolution, link only — no file attachment):
- *   1. catbox.moe  — permanent, 200 MB cap; 403s from CI IPs intermittently
- *   2. 0x0.st      — permanent (~1 yr for ~15 MB), works from CI IPs
- *   3. transfer.sh — auto-deletes after 24 h (Max-Days: 1), designed for CI
+ * Discord receives an MP4 attachment directly. Videos above the conservative
+ * attachment ceiling are transcoded to a temporary smaller MP4; the original
+ * YouTube master is never modified. External download hosts are fallback-only.
  */
 
 // catbox/litterbox sit behind Cloudflare and 403 requests that don't look like a
@@ -33,6 +40,176 @@ const CATBOX_HEADERS = {
   Origin: "https://catbox.moe",
   Referer: "https://catbox.moe/",
 };
+
+const DEFAULT_DISCORD_ATTACHMENT_MAX_BYTES = 8 * 1024 * 1024;
+const DISCORD_ATTACHMENT_AUDIO_KBPS = 96;
+
+export function buildUploadNotificationMessage(
+  post,
+  youtubeId,
+  downloadUrl = null,
+) {
+  return (
+    `✅ **New Short uploaded**\n` +
+    `📺 ${videoHeadlineTitle(post)}\n` +
+    `🎬 https://www.youtube.com/shorts/${youtubeId}\n` +
+    `🌐 https://thisday.info/blog/${post.slug}/` +
+    (downloadUrl ? `\n📥 Download MP4: ${downloadUrl}` : ``)
+  );
+}
+
+function discordAttachmentMaxBytes() {
+  const configuredMb = Number.parseFloat(
+    process.env.DISCORD_ATTACHMENT_MAX_MB ||
+      String(DEFAULT_DISCORD_ATTACHMENT_MAX_BYTES / 1024 / 1024),
+  );
+  const safeMb = Number.isFinite(configuredMb)
+    ? Math.min(25, Math.max(1, configuredMb))
+    : 8;
+  return Math.floor(safeMb * 1024 * 1024);
+}
+
+export function discordAttachmentVideoBitrateKbps(
+  durationSeconds,
+  targetBytes,
+  audioKbps = DISCORD_ATTACHMENT_AUDIO_KBPS,
+) {
+  const duration = Math.max(1, Number(durationSeconds) || 1);
+  const bytes = Math.max(1024 * 1024, Number(targetBytes) || 0);
+  const totalKbps = Math.floor((bytes * 8) / duration / 1000);
+  return Math.max(320, totalKbps - audioKbps - 32);
+}
+
+function videoDurationSeconds(videoPath) {
+  const raw = execFileSync(
+    "ffprobe",
+    [
+      "-v",
+      "error",
+      "-show_entries",
+      "format=duration",
+      "-of",
+      "default=noprint_wrappers=1:nokey=1",
+      videoPath,
+    ],
+    { encoding: "utf8", timeout: 30_000 },
+  ).trim();
+  const duration = Number.parseFloat(raw);
+  if (!Number.isFinite(duration) || duration <= 0) {
+    throw new Error("ffprobe did not return a valid video duration");
+  }
+  return duration;
+}
+
+function prepareDiscordAttachment(videoPath, post) {
+  const maxBytes = discordAttachmentMaxBytes();
+  const originalSize = statSync(videoPath).size;
+  if (originalSize <= maxBytes) {
+    return {
+      path: videoPath,
+      filename: `${post.slug}.mp4`,
+      cleanup: () => {},
+    };
+  }
+
+  const workDir = mkdtempSync(join(tmpdir(), "thisday-discord-"));
+  const outputPath = join(workDir, `${post.slug}.mp4`);
+  try {
+    const duration = videoDurationSeconds(videoPath);
+    // Leave container/metadata headroom beneath Discord's limit.
+    const targetBytes = Math.floor(maxBytes * 0.84);
+    const videoKbps = discordAttachmentVideoBitrateKbps(
+      duration,
+      targetBytes,
+    );
+    execFileSync(
+      "ffmpeg",
+      [
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-y",
+        "-i",
+        videoPath,
+        "-map",
+        "0:v:0",
+        "-map",
+        "0:a?",
+        "-c:v",
+        "libx264",
+        "-preset",
+        "veryfast",
+        "-b:v",
+        `${videoKbps}k`,
+        "-maxrate",
+        `${videoKbps}k`,
+        "-bufsize",
+        `${videoKbps * 2}k`,
+        "-c:a",
+        "aac",
+        "-b:a",
+        `${DISCORD_ATTACHMENT_AUDIO_KBPS}k`,
+        "-movflags",
+        "+faststart",
+        outputPath,
+      ],
+      { timeout: 180_000 },
+    );
+    const outputSize = statSync(outputPath).size;
+    if (outputSize > maxBytes) {
+      throw new Error(
+        `compressed attachment is ${(outputSize / 1048576).toFixed(1)} MB`,
+      );
+    }
+    console.log(
+      `  ✓ Discord attachment prepared: ${(outputSize / 1048576).toFixed(1)} MB`,
+    );
+    return {
+      path: outputPath,
+      filename: `${post.slug}.mp4`,
+      cleanup: () => rmSync(workDir, { recursive: true, force: true }),
+    };
+  } catch (error) {
+    rmSync(workDir, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+async function sendDiscordVideoAttachment(
+  discord,
+  post,
+  youtubeId,
+  videoPath,
+) {
+  const attachment = prepareDiscordAttachment(videoPath, post);
+  try {
+    const form = new FormData();
+    form.append(
+      "payload_json",
+      JSON.stringify({
+        content: buildUploadNotificationMessage(post, youtubeId),
+      }),
+    );
+    form.append(
+      "files[0]",
+      new Blob([readFileSync(attachment.path)], { type: "video/mp4" }),
+      attachment.filename,
+    );
+    const webhook = new URL(discord);
+    webhook.searchParams.set("wait", "true");
+    const response = await fetch(webhook, { method: "POST", body: form });
+    if (!response.ok) {
+      const detail = (await response.text()).trim().slice(0, 160);
+      throw new Error(
+        `Discord attachment upload failed: HTTP ${response.status}${detail ? ` (${detail})` : ""}`,
+      );
+    }
+    console.log("  ✓ Discord notified (MP4 attachment)");
+    return true;
+  } finally {
+    attachment.cleanup();
+  }
+}
 
 async function uploadToCatbox(videoPath, post) {
   const { size } = statSync(videoPath);
@@ -102,24 +279,36 @@ export async function notifyUpload(post, youtubeId, videoPath = null) {
   const slack = process.env.SLACK_WEBHOOK_URL;
   if (!discord && !slack) return;
 
+  let discordAttached = false;
+  if (discord && videoPath) {
+    discordAttached = await sendDiscordVideoAttachment(
+      discord,
+      post,
+      youtubeId,
+      videoPath,
+    ).catch((error) => {
+      console.warn(`  ⚠ Discord attachment error: ${error.message}`);
+      return false;
+    });
+  }
+
   let downloadUrl = null;
-  if (videoPath) {
+  if (videoPath && ((!discordAttached && discord) || slack)) {
     downloadUrl = await getDownloadUrl(videoPath, post);
     if (!downloadUrl) {
       console.warn("  ⚠ All upload hosts failed — Discord notification will have no video link");
     }
   }
 
-  const message =
-    `✅ **New Short uploaded**\n` +
-    `📺 ${videoHeadlineTitle(post)}\n` +
-    `🎬 https://www.youtube.com/shorts/${youtubeId}\n` +
-    `🌐 https://thisday.info/blog/${post.slug}/` +
-    (downloadUrl ? `\n📥 Download MP4: ${downloadUrl}` : ``);
+  const message = buildUploadNotificationMessage(
+    post,
+    youtubeId,
+    downloadUrl,
+  );
 
   const sends = [];
 
-  if (discord) {
+  if (discord && !discordAttached) {
     sends.push(
       fetch(discord, {
         method: "POST",
@@ -150,6 +339,7 @@ export async function notifyUpload(post, youtubeId, videoPath = null) {
   }
 
   await Promise.all(sends);
+  return { discordAttached, downloadUrl };
 }
 
 /**

--- a/youtube-upload/lib/video.js
+++ b/youtube-upload/lib/video.js
@@ -2,8 +2,8 @@
  * Generates a YouTube Shorts MP4 (1080x1920) from a blog post.
  *
  * Background visuals:
- *   default path        → multi-scene wiki mode using article images first,
- *                         then Wikipedia/Wikimedia Commons fallbacks
+ *   default path        → one-to-three scenes using only images stored in
+ *                         the exact blog article
  *   USE_AI_IMAGE=false  → legacy single-image path using post.imageUrl
  *
  * Captions:
@@ -47,11 +47,11 @@ if (!LORA_BOLD_EXISTS) console.warn("  ⚠ Lora-Bold.ttf not found — falling b
 // Custom background image for the title panel (1080×480, dark green textured bg)
 const TEXT_BG_PATH = join(dirname(fileURLToPath(import.meta.url)), "../assets/text-bg.png");
 /**
- * Prefer three full-bleed article images. Articles with only two distinct,
- * usable images still qualify as multi-scene; a one-image result fails closed.
+ * Prefer three full-bleed article images, but a single usable image is valid
+ * and becomes one continuous Ken Burns scene for the complete video.
  */
 export const VIDEO_SCENE_COUNT = 3;
-export const MIN_MULTI_SCENE_IMAGES = 2;
+export const MIN_MULTI_SCENE_IMAGES = 1;
 const N_SCENES = VIDEO_SCENE_COUNT;
 
 // Gentle crossfade only — slide/wipe transitions are too jarring for a calm history channel
@@ -1186,46 +1186,18 @@ async function fetchArticleImageBuffers(
   return buffers;
 }
 
-async function fetchPreferredVideoImageBuffers(post, articleSource, limit, context = {}) {
-  const buffers = [];
-  const featuredUrl = post?.imageUrl || null;
+async function fetchPreferredVideoImageBuffers(post, limit) {
   const seenIdentities = new Set();
-
-  if (featuredUrl) {
-    try {
-      const featuredBuffer = await downloadImageBuffer(featuredUrl);
-      buffers.push(featuredBuffer);
-      const identity = normalizeVideoImageIdentity(featuredUrl);
-      if (identity) seenIdentities.add(identity);
-      console.log("  ✓ Using blog featured image as primary video image");
-    } catch (err) {
-      console.warn(`  ⚠ Featured image unavailable for video (${err.message}) — falling back to Wikipedia article images`);
-    }
-  }
-
-  if (buffers.length >= limit) return buffers.slice(0, limit);
-
-  const articleBuffers = await fetchArticleImageBuffers(
+  const buffers = await fetchArticleImageBuffers(
     post?.slug,
-    limit - buffers.length,
+    limit,
     seenIdentities,
   );
-  buffers.push(...articleBuffers);
-  if (articleBuffers.length > 0) {
+  if (buffers.length > 0) {
     console.log(
-      `  ✓ Added ${articleBuffers.length} distinct inline article image(s)`,
+      `  ✓ Loaded ${buffers.length} distinct image(s) from the stored article`,
     );
   }
-
-  if (buffers.length >= limit) return buffers.slice(0, limit);
-
-  const fallbackBuffers = await fetchWikipediaImageBuffers(
-    articleSource,
-    limit - buffers.length,
-    context,
-    seenIdentities,
-  );
-  buffers.push(...fallbackBuffers);
   return buffers.slice(0, limit);
 }
 
@@ -1610,8 +1582,6 @@ async function generateMultiSceneVideo(
     narrationPath,
     bgMusicPath,
     words,
-    contentItems,
-    wikiArticleUrl,
     narrationParts,
     videoPath,
     qualityHint = null,
@@ -1633,40 +1603,21 @@ async function generateMultiSceneVideo(
       : `  Video duration: ${videoDuration} s (default — no word timestamps)`,
   );
 
-  // 1. Use the article's featured image first. This keeps the video aligned with
-  // the published blog post; Wikipedia article images are only fallback material.
-  const fallbackTitle = videoMatchTitle(post).replace(/\s*[—–-]\s+\w+ \d{1,2},\s*\d{4}$/, "").trim();
-  const articleSource = wikiArticleUrl || fallbackTitle;
-  console.log(`  Fetching featured/article image for "${slug}"...`);
-  const imageBuffers = await fetchPreferredVideoImageBuffers(post, articleSource, N_SCENES, {
-    contentItems,
-  });
+  // Use only imagery already stored inside this exact blog article. If the
+  // article has one image, that image carries the full video; if it has more,
+  // use at most three in article order.
+  console.log(`  Fetching exact article images for "${slug}"...`);
+  const imageBuffers = await fetchPreferredVideoImageBuffers(post, N_SCENES);
 
-  if (imageBuffers.length === 0) {
+  if (imageBuffers.length < MIN_MULTI_SCENE_IMAGES) {
     throw new Error(
-      "IMAGE_UNAVAILABLE: no usable featured image or exact Wikipedia article image",
-    );
-  }
-
-  const configuredMinWikiImages =
-    Number.parseInt(
-      process.env.WIKI_IMAGE_MIN_COUNT || `${MIN_MULTI_SCENE_IMAGES}`,
-      10,
-    ) || MIN_MULTI_SCENE_IMAGES;
-  const minWikiImages = Math.min(
-    N_SCENES,
-    Math.max(MIN_MULTI_SCENE_IMAGES, configuredMinWikiImages),
-  );
-
-  if (imageBuffers.length < minWikiImages) {
-    throw new Error(
-      `IMAGE_UNAVAILABLE: exact Wikipedia article mode requires ${minWikiImages} usable article images, got ${imageBuffers.length}`,
+      "IMAGE_UNAVAILABLE: no usable image stored in the exact blog article",
     );
   }
 
   const sceneCount = Math.min(N_SCENES, imageBuffers.length);
   console.log(
-    `  ✓ Using ${sceneCount} real image(s) for video (featured first, min=${minWikiImages})`,
+    `  ✓ Using ${sceneCount} image(s) from the exact blog article (featured first, max=${N_SCENES})`,
   );
 
   const sceneLayers = await Promise.all(
@@ -1931,7 +1882,7 @@ async function generateMultiSceneVideo(
  *   narrationPath?: string|null,  ElevenLabs TTS audio — played once at 100% volume
  *   bgMusicPath?:   string|null,  Background music — looped at 33% volume
  *   words?:         { word: string, start: number, end: number }[],  Caption timestamps
- *   useAiImage?:    boolean,      When true, use the multi-scene wiki-image path
+ *   useAiImage?:    boolean,      When true, use the article-image scene path
  *                                 (legacy name kept for compatibility)
  * }} [opts]
  * @returns {Promise<{ path: string, cuts: number[] }>} path to the MP4 and scene cut timestamps
@@ -1943,8 +1894,6 @@ export async function generateVideo(
     bgMusicPath,
     words = [],
     useAiImage = false,
-    contentItems = null,
-    wikiArticleUrl = null,
     narrationParts = null,
     qualityHint = null, // remediation directive from a failed quality check
   } = {},
@@ -1956,14 +1905,12 @@ export async function generateVideo(
   const framePath = join(TMP, `${slug}_frame.png`);
   const videoPath = join(TMP, `${slug}.mp4`);
 
-  // Multi-scene: article/Wikipedia images crossfaded at narration-timed boundaries
+  // Article-image mode: one image or up to three article figures.
   if (useAiImage) {
     return generateMultiSceneVideo(post, {
       narrationPath,
       bgMusicPath,
       words,
-      contentItems,
-      wikiArticleUrl,
       narrationParts,
       videoPath,
       qualityHint,

--- a/youtube-upload/package.json
+++ b/youtube-upload/package.json
@@ -12,6 +12,7 @@
     "generate": "node tests/generate-video.js",
     "test:unit": "node test-video-text.js && node test-history-expert.js && node test-narration-expert.js && node test-blog-quiz-expert.js",
     "test:video-text": "node test-video-text.js",
+    "promote-reviewed": "node promote-reviewed.js",
     "social-cron": "node scripts/social-cron.js",
     "test:social": "node tests/test-social.js"
   },

--- a/youtube-upload/preview.js
+++ b/youtube-upload/preview.js
@@ -11,7 +11,6 @@ import {
   getDidYouKnow,
   getOverviewNarration,
   getPostIndex,
-  getPostWikipediaUrl,
   getQuickFacts,
 } from "./lib/kv.js";
 import { generateVideo } from "./lib/video.js";
@@ -45,12 +44,11 @@ async function main() {
   console.log(`Post: ${post.title}`);
 
   // Narration content
-  const [overviewText, dyk, qf, articleText, wikiUrl] = await Promise.all([
+  const [overviewText, dyk, qf, articleText] = await Promise.all([
     getOverviewNarration(slug),
     getDidYouKnow(slug),
     getQuickFacts(slug),
     getArticleText(slug).catch(() => null),
-    getPostWikipediaUrl(slug),
   ]);
   const narration = prepareNarrationSource(post, {
     overviewText,
@@ -60,7 +58,6 @@ async function main() {
   });
   const topicContext = narration.topicContext;
   const narrationParts = narration.narrationParts;
-  const contentItems = narration.contentItems;
   console.log(
     narration.source === "overview"
       ? `Narration source: Overview (${narration.overviewAssessment.words} words)`
@@ -94,8 +91,6 @@ async function main() {
     bgMusicPath,
     words,
     useAiImage,
-    contentItems,
-    wikiArticleUrl: wikiUrl,
     narrationParts,
   });
 

--- a/youtube-upload/promote-reviewed.js
+++ b/youtube-upload/promote-reviewed.js
@@ -188,6 +188,13 @@ async function main() {
 
   if (retireOnly) {
     await updateUploaded(slug, {
+      // Keep the reviewed upload identity explicit. A fresh KV read inside
+      // updateUploaded can briefly return the pre-upload tracker value because
+      // Workers KV is eventually consistent; without these fields that stale
+      // value can restore the retired video ID.
+      youtubeId: tracked.youtubeId,
+      privacy: "public",
+      uploadedAt: tracked.uploadedAt,
       retiredYoutubeIds: [
         ...new Set([
           ...(Array.isArray(tracked.retiredYoutubeIds)
@@ -216,7 +223,14 @@ async function main() {
       );
     }
     await updateUploaded(slug, {
+      // Do not let an eventually-consistent read restore the replaced video.
+      youtubeId: tracked.youtubeId,
       privacy: "public",
+      uploadedAt: tracked.uploadedAt,
+      replacesYoutubeId: tracked.replacesYoutubeId || "",
+      replacesYoutubeIds: Array.isArray(tracked.replacesYoutubeIds)
+        ? tracked.replacesYoutubeIds
+        : [],
       reviewedAt: new Date().toISOString(),
       topicAudit: {
         ...storedAudit,

--- a/youtube-upload/test-video-text.js
+++ b/youtube-upload/test-video-text.js
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 
 import {
+  extractPostArticleImageUrls,
   extractArticleTextFromHtml,
   extractDidYouKnowFromHtml,
   extractOverviewNarrationFromHtml,
@@ -34,6 +36,10 @@ import {
   collectReplacedYoutubeIds,
   isUploadLockActive,
 } from "./lib/tracker.js";
+import {
+  buildUploadNotificationMessage,
+  discordAttachmentVideoBitrateKbps,
+} from "./lib/notify.js";
 
 const TITLE =
   "John F. Kennedy Jr. Dies in Plane Crash — July 16, 1999";
@@ -172,7 +178,7 @@ function testOverviewAuditPreservesNarrativeContext() {
 
 function testMultiImageVideoConfiguration() {
   assert.equal(VIDEO_SCENE_COUNT, 3);
-  assert.equal(MIN_MULTI_SCENE_IMAGES, 2);
+  assert.equal(MIN_MULTI_SCENE_IMAGES, 1);
   assert.equal(VIDEO_DURATION_LIMIT_S, 60);
   assert.equal(BACKGROUND_MUSIC_VOLUME, 0.33);
 
@@ -185,6 +191,69 @@ function testMultiImageVideoConfiguration() {
   assert.equal(
     normalizeVideoImageIdentity(original),
     normalizeVideoImageIdentity(proxiedThumbnail),
+  );
+}
+
+function testVideoImagesComeOnlyFromTheExactArticle() {
+  const hero =
+    "https://upload.wikimedia.org/wikipedia/en/9/98/Wade_Frankum.jpg";
+  const inline =
+    "https://upload.wikimedia.org/wikipedia/commons/a/a1/Exact_article_scene.jpg";
+  const related =
+    "https://upload.wikimedia.org/wikipedia/commons/0/04/Port_Arthur%2C_Tasmania.JPG";
+  const quiz =
+    "https://upload.wikimedia.org/wikipedia/commons/e/ea/Quiz_art.jpg";
+  const html = `
+    <figure class="text-center article-hero-fig">
+      <img src="/image-proxy?src=${encodeURIComponent(hero)}&w=800&q=85">
+    </figure>
+    <section><!-- Overview -->
+      <figure style="float:right;margin-left:1rem">
+        <img src="${inline}">
+      </figure>
+    </section>
+    <a class="related-card"><img src="/image-proxy?src=${encodeURIComponent(related)}&w=80"></a>
+    <div class="tdq-float-bar"><img src="/image-proxy?src=${encodeURIComponent(quiz)}&w=176"></div>`;
+
+  assert.deepEqual(extractPostArticleImageUrls(html, 3), [hero, inline]);
+}
+
+function testReviewedPromotionPinsTheReplacementIdentity() {
+  const source = readFileSync(
+    new URL("./promote-reviewed.js", import.meta.url),
+    "utf8",
+  );
+  const promotionWrite = source.slice(
+    source.indexOf("try {\n    await setYoutubeVideoPrivacy"),
+    source.indexOf("} catch (error)", source.indexOf("try {\n    await setYoutubeVideoPrivacy")),
+  );
+  assert.match(promotionWrite, /youtubeId:\s*tracked\.youtubeId/);
+  assert.match(promotionWrite, /uploadedAt:\s*tracked\.uploadedAt/);
+}
+
+function testDiscordAttachmentBitrateLeavesAudioAndContainerHeadroom() {
+  const kbps = discordAttachmentVideoBitrateKbps(
+    46,
+    Math.floor(8 * 1024 * 1024 * 0.84),
+  );
+  assert.ok(kbps >= 1000 && kbps <= 1300, `unexpected bitrate: ${kbps}`);
+}
+
+function testDiscordAttachmentMessageKeepsYoutubeAndBlogLinks() {
+  const message = buildUploadNotificationMessage(
+    {
+      slug: "17-august-2026",
+      factualTitle: "A Historical Event — August 17, 2026",
+    },
+    "AbCdEfGhI12",
+  );
+  assert.match(
+    message,
+    /https:\/\/www\.youtube\.com\/shorts\/AbCdEfGhI12/,
+  );
+  assert.match(
+    message,
+    /https:\/\/thisday\.info\/blog\/17-august-2026\//,
   );
 }
 
@@ -475,6 +544,10 @@ testWeakOverviewFallsBackToCuratedFacts();
 testOverviewSourceResidueFailsClosed();
 testOverviewAuditPreservesNarrativeContext();
 testMultiImageVideoConfiguration();
+testVideoImagesComeOnlyFromTheExactArticle();
+testReviewedPromotionPinsTheReplacementIdentity();
+testDiscordAttachmentBitrateLeavesAudioAndContainerHeadroom();
+testDiscordAttachmentMessageKeepsYoutubeAndBlogLinks();
 testInterestingFactSelection();
 testNarrationContainsFactsOnly();
 testAllFillerFailsClosed();


### PR DESCRIPTION
## What changed

- replace Groq's retired Llama text models with GPT OSS 120B and Qwen 3.6 fallbacks
- keep large structured article requests within the established Groq token limits
- restrict YouTube video scenes to images stored in the exact blog article
- attach the MP4 to Discord while preserving the YouTube Shorts and blog links
- protect reviewed replacement-video metadata from eventually consistent KV reads
- align the tracked enrichment fixtures with the already-live evergreen edition gate

## Why

Groq retired the previous primary text models on August 16, 2026. The video pipeline also needed stricter image ownership, direct Discord delivery, and safer reviewed-upload reconciliation.

## Impact

The daily blog source, grounding, checkpoint, enrichment, and publication logic is unchanged. Only its model-routing layer changes. The remaining runtime changes are confined to the YouTube workflow.

## Validation

- 228 tracked Worker production tests
- 607 local route/schema tests
- 47 capacity/model regression tests
- complete YouTube unit suite and workflow gate
- SEO, Blog, RSS, and Sitemap Worker dry-run bundles
- GET-only checks of recent stored article image availability
